### PR TITLE
Exception handling improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ At the root directory prompt, execute the following maven command:
   
 Change directory to the target directory and execute the following command:  
   
-    java -jar zosshell-1.0.jar   
+    java -jar zosshell-2.0.jar   
   
 If you are planning to browse large job output you may want to set the JVM memory usage higher than the default, i.e.  
   
-    java -jar -Xmx2G zosshell-1.0.jar   
+    java -jar -Xmx2G zosshell-2.0.jar   
   
 ### Terminal configuration properties (optional)
   

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.zosshell</groupId>
     <artifactId>zosshell</artifactId>
-    <version>1.0</version>
+    <version>2.0</version>
 
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -64,10 +64,13 @@
                                         <exclude>META-INF/LICENSE.txt</exclude>
                                         <exclude>META-INF/LICENSE</exclude>
                                         <exclude>META-INF/DEPENDENCIES</exclude>
-                                        <exclude>META-INF/services/*</exclude>
+                                        <exculde>META-INF/services/com.fasterxml.jackson.core.ObjectCodec</exculde>
+                                        <exculde>META-INF/services/com.fasterxml.jackson.core.JsonFactory</exculde>
+                                        <exculde>META-INF/services/com.fasterxml.jackson.databind.Module</exculde>
                                         <exclude>LICENSE.txt</exclude>
                                         <exclude>about.html</exclude>
                                         <exclude>META-INF/NOTICE</exclude>
+                                        <exclude>META-INF/versions/9/module-info.class</exclude>
                                         <exclude>META-INF/NOTICE.txt</exclude>
                                         <exclude>module-info.class</exclude>
                                         <exclude>META-INF/maven/com.starxg/java-keytar/pom.properties</exclude>
@@ -100,26 +103,12 @@
             <groupId>org.beryx</groupId>
             <artifactId>text-io</artifactId>
             <version>3.4.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.beryx</groupId>
             <artifactId>text-io-web</artifactId>
             <version>3.4.1</version>
             <exclusions>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>com.google.code.gson</groupId>
                     <artifactId>gson</artifactId>
@@ -143,81 +132,13 @@
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>com.google.inject</groupId>
-                    <artifactId>guice</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.yaml</groupId>
-                    <artifactId>snakeyaml</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.ratpack</groupId>
-            <artifactId>ratpack-session</artifactId>
-            <version>1.9.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sparkjava</groupId>
-            <artifactId>spark-core</artifactId>
-            <version>2.9.4</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-http</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-server</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-xml</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-util</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.zowe.client.java.sdk</groupId>
             <artifactId>zowe-client-java-sdk</artifactId>
-            <version>2.1.4</version>
+            <version>2.2.0</version>
             <exclusions>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-text</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-io</groupId>
-                    <artifactId>commons-io</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>com.googlecode.json-simple</groupId>
                     <artifactId>json-simple</artifactId>
@@ -227,40 +148,12 @@
                     <artifactId>guava</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>com.jcraft</groupId>
                     <artifactId>jsch</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>com.starxg</groupId>
                     <artifactId>java-keytar</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.code.gson</groupId>
-                    <artifactId>gson</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpasyncclient</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpcore-nio</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpmime</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.konghq</groupId>
-                    <artifactId>unirest-java</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>com.konghq</groupId>
@@ -280,34 +173,23 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.21.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>2.22.1</version>
         </dependency>
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http</artifactId>
-            <version>4.1.90.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec</artifactId>
-            <version>4.1.90.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-common</artifactId>
-            <version>4.1.90.Final</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.10</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.13.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.14.0</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
         <dependency>
             <groupId>org.zowe.client.java.sdk</groupId>
             <artifactId>zowe-client-java-sdk</artifactId>
-            <version>2.0.3</version>
+            <version>2.1.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
         <dependency>
             <groupId>org.zowe.client.java.sdk</groupId>
             <artifactId>zowe-client-java-sdk</artifactId>
-            <version>2.1.2</version>
+            <version>2.1.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.commons</groupId>

--- a/src/main/java/zos/shell/ZosShell.java
+++ b/src/main/java/zos/shell/ZosShell.java
@@ -597,10 +597,7 @@ public class ZosShell implements BiConsumer<TextIO, RunnerData> {
                     return;
                 }
                 disableKeys = true;
-                try {
-                    commands.mkdir(currConnection, mainTextIO, currDataSet, params[1]);
-                } catch (Exception ignore) {
-                }
+                commands.mkdir(currConnection, mainTextIO, currDataSet, params[1]);
                 disableKeys = false;
                 break;
             case "mvs":

--- a/src/main/java/zos/shell/commands/ChangeDir.java
+++ b/src/main/java/zos/shell/commands/ChangeDir.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zos.shell.Constants;
 import zos.shell.utility.Util;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosfiles.dsn.input.ListParams;
 import zowe.client.sdk.zosfiles.dsn.methods.DsnList;
 import zowe.client.sdk.zosfiles.dsn.response.Dataset;
@@ -50,8 +51,12 @@ public class ChangeDir {
             List<Dataset> dsLst;
             try {
                 dsLst = dsnList.getDatasets(currDataSet, params);
-            } catch (Exception e) {
-                Util.printError(terminal, e.getMessage());
+            } catch (ZosmfRequestException e) {
+                final String errMsg = Util.getResponsePhrase(e.getResponse());
+                terminal.println((errMsg != null ? errMsg : e.getMessage()));
+                return currDataSet;
+            } catch (IllegalArgumentException e) {
+                terminal.println(Constants.DATASET_NOT_SPECIFIED);
                 return currDataSet;
             }
             var findDataSet = currDataSet + "." + param;

--- a/src/main/java/zos/shell/commands/Concatenate.java
+++ b/src/main/java/zos/shell/commands/Concatenate.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import zos.shell.Constants;
 import zos.shell.dto.ResponseStatus;
 import zos.shell.utility.Util;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,7 +34,10 @@ public class Concatenate {
                 inputStream = download.getInputStream(target);
             }
             result = retrieveInfo(inputStream);
-        } catch (Exception e) {
+        } catch (ZosmfRequestException e) {
+            final String errMsg = Util.getResponsePhrase(e.getResponse());
+            return new ResponseStatus((errMsg != null ? errMsg : e.getMessage()), false);
+        } catch (IOException e) {
             return new ResponseStatus(e.getMessage(), false);
         }
         return new ResponseStatus(result, true);

--- a/src/main/java/zos/shell/commands/Copy.java
+++ b/src/main/java/zos/shell/commands/Copy.java
@@ -6,6 +6,7 @@ import zos.shell.Constants;
 import zos.shell.dto.DataSetMember;
 import zos.shell.dto.ResponseStatus;
 import zos.shell.utility.Util;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosfiles.dsn.methods.DsnCopy;
 
 public class Copy {
@@ -121,8 +122,9 @@ public class Copy {
         }
         try {
             DsnCopy.copy(fromDataSetName, toDataSetName, true, copyAllMembers);
-        } catch (Exception e) {
-            return new ResponseStatus(e.getMessage(), false);
+        } catch (ZosmfRequestException e) {
+            final String errMsg = Util.getResponsePhrase(e.getResponse());
+            return new ResponseStatus((errMsg != null ? errMsg : e.getMessage()), false);
         }
         return new ResponseStatus("copied to " + toDataSetName, true);
     }

--- a/src/main/java/zos/shell/commands/CopySequential.java
+++ b/src/main/java/zos/shell/commands/CopySequential.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import zos.shell.Constants;
 import zos.shell.dto.ResponseStatus;
 import zos.shell.utility.Util;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosfiles.dsn.methods.DsnCopy;
 
 public class CopySequential {
@@ -69,8 +70,9 @@ public class CopySequential {
 
         try {
             DsnCopy.copy(fromDataSetName, toDataSetName, true, false);
-        } catch (Exception e) {
-            return new ResponseStatus(e.getMessage(), false);
+        } catch (ZosmfRequestException e) {
+            final String errMsg = Util.getResponsePhrase(e.getResponse());
+            return new ResponseStatus((errMsg != null ? errMsg : e.getMessage()), false);
         }
         return new ResponseStatus("copied to " + toDataSetName, true);
     }

--- a/src/main/java/zos/shell/commands/Count.java
+++ b/src/main/java/zos/shell/commands/Count.java
@@ -3,6 +3,8 @@ package zos.shell.commands;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zos.shell.dto.ResponseStatus;
+import zos.shell.utility.Util;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosfiles.dsn.input.ListParams;
 import zowe.client.sdk.zosfiles.dsn.methods.DsnList;
 import zowe.client.sdk.zosfiles.dsn.response.Dataset;
@@ -41,8 +43,9 @@ public class Count {
                     dataSetCount.getAndIncrement();
                 }
             });
-        } catch (Exception e) {
-            return new ResponseStatus("0", false);
+        } catch (ZosmfRequestException e) {
+            final String errMsg = Util.getResponsePhrase(e.getResponse());
+            return new ResponseStatus((errMsg != null ? errMsg : e.getMessage()), false);
         }
         return new ResponseStatus(String.valueOf(members.size() + dataSetCount.get()), true);
     }

--- a/src/main/java/zos/shell/commands/Download.java
+++ b/src/main/java/zos/shell/commands/Download.java
@@ -9,6 +9,7 @@ import zos.shell.Constants;
 import zos.shell.dto.ResponseStatus;
 import zos.shell.utility.DirectorySetup;
 import zos.shell.utility.Util;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosfiles.dsn.input.DownloadParams;
 import zowe.client.sdk.zosfiles.dsn.methods.DsnGet;
 
@@ -46,7 +47,7 @@ public class Download {
         try {
             dirSetup.initialize(dataSet, member);
         } catch (Exception e) {
-            return new ResponseStatus(message + Constants.OS_ERROR, false);
+            return new ResponseStatus(message + e.getMessage(), false);
         }
 
         try {
@@ -69,7 +70,10 @@ public class Download {
                 writeBinaryFile(binaryContent, dirSetup.getDirectoryPath(), dirSetup.getFileNamePath());
             }
             message += "downloaded to " + dirSetup.getFileNamePath();
-        } catch (Exception e) {
+        } catch (ZosmfRequestException e) {
+            final String errMsg = Util.getResponsePhrase(e.getResponse());
+            return new ResponseStatus(message + (errMsg != null ? errMsg : e.getMessage()), false);
+        } catch (IOException e) {
             return new ResponseStatus(message + e.getMessage(), false);
         }
         return new ResponseStatus(message, true, dirSetup.getFileNamePath());
@@ -82,7 +86,7 @@ public class Download {
         try {
             dirSetup.initialize(Constants.SEQUENTIAL_DIRECTORY_LOCATION, dataSet);
         } catch (Exception e) {
-            return new ResponseStatus(message + Constants.OS_ERROR, false);
+            return new ResponseStatus(message + e.getMessage(), false);
         }
 
         try {
@@ -93,7 +97,10 @@ public class Download {
             }
             Util.writeTextFile(textContent, dirSetup.getDirectoryPath(), dirSetup.getFileNamePath());
 
-        } catch (Exception e) {
+        } catch (ZosmfRequestException e) {
+            final String errMsg = Util.getResponsePhrase(e.getResponse());
+            return new ResponseStatus(message + (errMsg != null ? errMsg : e.getMessage()), false);
+        } catch (IOException e) {
             return new ResponseStatus(message + e.getMessage(), false);
         }
 
@@ -107,24 +114,24 @@ public class Download {
         FileUtils.copyInputStreamToFile(input, new File(fileNamePath));
     }
 
-    private String getTextContent(String dataSet, String member) throws Exception {
+    private String getTextContent(String dataSet, String member) throws ZosmfRequestException, IOException {
         LOG.debug("*** getTextContent member ***");
         final var inputStream = getInputStream(String.format("%s(%s)", dataSet, member));
         return getTextStreamData(inputStream);
     }
 
-    private String getTextContent(String dataSet) throws Exception {
+    private String getTextContent(String dataSet) throws ZosmfRequestException, IOException {
         LOG.debug("*** getTextContent member ***");
         final var inputStream = getInputStream(dataSet);
         return getTextStreamData(inputStream);
     }
 
-    private InputStream getBinaryContent(String dataSet, String member) {
+    private InputStream getBinaryContent(String dataSet, String member) throws ZosmfRequestException {
         LOG.debug("*** getBinaryContent member ***");
         return getInputStream(String.format("%s(%s)", dataSet, member));
     }
 
-    public InputStream getInputStream(String target) {
+    public InputStream getInputStream(String target) throws ZosmfRequestException {
         LOG.debug("*** getInputStream ***");
         if (dlParams == null) {
             dlParams = new DownloadParams.Builder().build();

--- a/src/main/java/zos/shell/commands/Download.java
+++ b/src/main/java/zos/shell/commands/Download.java
@@ -46,7 +46,7 @@ public class Download {
         final var dirSetup = new DirectorySetup();
         try {
             dirSetup.initialize(dataSet, member);
-        } catch (Exception e) {
+        } catch (IllegalStateException e) {
             return new ResponseStatus(message + e.getMessage(), false);
         }
 
@@ -85,7 +85,7 @@ public class Download {
 
         try {
             dirSetup.initialize(Constants.SEQUENTIAL_DIRECTORY_LOCATION, dataSet);
-        } catch (Exception e) {
+        } catch (IllegalStateException e) {
             return new ResponseStatus(message + e.getMessage(), false);
         }
 

--- a/src/main/java/zos/shell/commands/DownloadJob.java
+++ b/src/main/java/zos/shell/commands/DownloadJob.java
@@ -9,6 +9,7 @@ import zos.shell.utility.DirectorySetup;
 import zos.shell.utility.Util;
 import zowe.client.sdk.zosjobs.methods.JobGet;
 
+import java.io.IOException;
 import java.util.Comparator;
 
 public class DownloadJob {
@@ -42,13 +43,13 @@ public class DownloadJob {
         final var dirSetup = new DirectorySetup();
         try {
             dirSetup.initialize(name, id);
-        } catch (Exception e) {
+        } catch (IllegalStateException e) {
             return new ResponseStatus(e.getMessage(), false);
         }
 
         try {
             Util.writeTextFile(output, dirSetup.getDirectoryPath(), dirSetup.getFileNamePath());
-        } catch (Exception e) {
+        } catch (IOException e) {
             return new ResponseStatus(e.getMessage(), false);
         }
 

--- a/src/main/java/zos/shell/commands/Listing.java
+++ b/src/main/java/zos/shell/commands/Listing.java
@@ -71,12 +71,12 @@ public class Listing {
             if (m.equals(searchForMember)) {
                 members = members.stream()
                         .filter(i -> i.getMember().orElse("")
-                                .equals(searchForMember))
+                        .equals(searchForMember))
                         .collect(Collectors.toList());
             } else {
                 members = members.stream()
                         .filter(i -> i.getMember().orElse("")
-                                .startsWith(searchForMember))
+                        .startsWith(searchForMember))
                         .collect(Collectors.toList());
             }
         }, () -> displayDataSets(dataSets, dataSet, isColumnView, isAttributes));

--- a/src/main/java/zos/shell/commands/Listing.java
+++ b/src/main/java/zos/shell/commands/Listing.java
@@ -62,7 +62,7 @@ public class Listing {
             members = getMembers(dataSet);
         } catch (TimeoutException e) {
             throw new TimeoutException(e.getMessage());
-        } catch (Exception ignored) {
+        } catch (ExecutionException | InterruptedException ignored) {
         }
 
         member.ifPresentOrElse((m) -> {

--- a/src/main/java/zos/shell/commands/MakeDirectory.java
+++ b/src/main/java/zos/shell/commands/MakeDirectory.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zos.shell.dto.ResponseStatus;
 import zos.shell.utility.Util;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosfiles.dsn.input.CreateParams;
 import zowe.client.sdk.zosfiles.dsn.methods.DsnCreate;
 
@@ -22,8 +23,9 @@ public class MakeDirectory {
         LOG.debug("*** mkdir ***");
         try {
             dsnCreate.create(dataset, params);
-        } catch (Exception e) {
-            return new ResponseStatus(Util.getErrorMsg(e.getMessage()), false);
+        } catch (ZosmfRequestException e) {
+            final String errMsg = Util.getResponsePhrase(e.getResponse());
+            return new ResponseStatus((errMsg != null ? errMsg : e.getMessage()), false);
         }
 
         return new ResponseStatus(dataset + " created successfully...", true);

--- a/src/main/java/zos/shell/commands/ProcessList.java
+++ b/src/main/java/zos/shell/commands/ProcessList.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import zos.shell.Constants;
 import zos.shell.dto.ResponseStatus;
 import zos.shell.utility.Util;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosjobs.input.GetJobParams;
 import zowe.client.sdk.zosjobs.methods.JobGet;
 import zowe.client.sdk.zosjobs.response.Job;
@@ -33,8 +34,9 @@ public class ProcessList {
             }
             final var params = getJobParams.build();
             jobs = jobGet.getCommon(params);
-        } catch (Exception e) {
-            return new ResponseStatus(Util.getErrorMsg(e.getMessage()), false);
+        } catch (ZosmfRequestException e) {
+            final String errMsg = Util.getResponsePhrase(e.getResponse());
+            return new ResponseStatus((errMsg != null ? errMsg : e.getMessage()), false);
         }
         jobs.sort(Comparator.comparing((Job j) -> j.getJobName().orElse(""))
                 .thenComparing(j -> j.getStatus().orElse(""))

--- a/src/main/java/zos/shell/commands/PurgeJob.java
+++ b/src/main/java/zos/shell/commands/PurgeJob.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import zos.shell.dto.ResponseStatus;
 import zos.shell.utility.Util;
 import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosjobs.input.ModifyJobParams;
 import zowe.client.sdk.zosjobs.methods.JobDelete;
 import zowe.client.sdk.zosjobs.methods.JobGet;
@@ -35,8 +36,9 @@ public class PurgeJob {
         List<Job> jobs;
         try {
             jobs = jobGet.getByPrefix(jobName);
-        } catch (Exception e) {
-            return new ResponseStatus(Util.getErrorMsg(e.getMessage()), false);
+        } catch (ZosmfRequestException e) {
+            final String errMsg = Util.getResponsePhrase(e.getResponse());
+            return new ResponseStatus((errMsg != null ? errMsg : e.getMessage()), false);
         }
 
         if (jobs.isEmpty()) {
@@ -54,8 +56,9 @@ public class PurgeJob {
         Job job;
         try {
             job = jobGet.getById(jobId);
-        } catch (Exception e) {
-            return new ResponseStatus(Util.getErrorMsg(e.getMessage()), false);
+        } catch (ZosmfRequestException e) {
+            final String errMsg = Util.getResponsePhrase(e.getResponse());
+            return new ResponseStatus((errMsg != null ? errMsg : e.getMessage()), false);
         }
 
         if (job == null) {
@@ -85,8 +88,9 @@ public class PurgeJob {
             jobDelete.deleteCommon(modifyJobParams);
             return new ResponseStatus("Job Name: " + job.getJobName().get() +
                     ", Job Id: " + job.getJobId().get() + " purged successfully...", true);
-        } catch (Exception e) {
-            return new ResponseStatus(Util.getErrorMsg(e.getMessage()), false);
+        } catch (ZosmfRequestException e) {
+            final String errMsg = Util.getResponsePhrase(e.getResponse());
+            return new ResponseStatus((errMsg != null ? errMsg : e.getMessage()), false);
         }
     }
 

--- a/src/main/java/zos/shell/commands/Save.java
+++ b/src/main/java/zos/shell/commands/Save.java
@@ -6,10 +6,12 @@ import org.slf4j.LoggerFactory;
 import zos.shell.Constants;
 import zos.shell.dto.ResponseStatus;
 import zos.shell.utility.Util;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosfiles.dsn.methods.DsnWrite;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
+import java.io.IOException;
 
 public class Save {
 
@@ -60,8 +62,11 @@ public class Save {
             } else {
                 dsnWrite.write(dataSet, member, content);
             }
-        } catch (Exception e) {
-            return new ResponseStatus(Util.getErrorMsg(e.getMessage()), false);
+        } catch (ZosmfRequestException e) {
+            final String errMsg = Util.getResponsePhrase(e.getResponse());
+            return new ResponseStatus((errMsg != null ? errMsg : e.getMessage()), false);
+        } catch (IOException e) {
+            return new ResponseStatus(e.getMessage(), false);
         }
 
         return new ResponseStatus(member + " successfully saved...", true);

--- a/src/main/java/zos/shell/commands/Submit.java
+++ b/src/main/java/zos/shell/commands/Submit.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zos.shell.dto.ResponseStatus;
 import zos.shell.utility.Util;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosjobs.methods.JobSubmit;
 import zowe.client.sdk.zosjobs.response.Job;
 
@@ -23,8 +24,9 @@ public class Submit {
         Job job;
         try {
             job = jobSubmit.submit(String.format("%s(%s)", dataSet, param));
-        } catch (Exception e) {
-            return new ResponseStatus(Util.getErrorMsg(e.getMessage()), false);
+        } catch (ZosmfRequestException e) {
+            final String errMsg = Util.getResponsePhrase(e.getResponse());
+            return new ResponseStatus((errMsg != null ? errMsg : e.getMessage()), false);
         }
         return new ResponseStatus("Job Name: " + job.getJobName().orElse("n\\a") +
                 ", Job Id: " + job.getJobId().orElse("n\\a"), true);

--- a/src/main/java/zos/shell/commands/Tail.java
+++ b/src/main/java/zos/shell/commands/Tail.java
@@ -5,7 +5,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zos.shell.Constants;
 import zos.shell.dto.ResponseStatus;
-import zos.shell.utility.Util;
 import zowe.client.sdk.zosjobs.methods.JobGet;
 
 import java.util.Arrays;
@@ -25,18 +24,7 @@ public class Tail extends JobLog {
 
     public ResponseStatus tail(String[] params) {
         LOG.debug("*** tail ***");
-        ResponseStatus result;
-        try {
-            result = browseJobLog(params[1]);
-        } catch (Exception e) {
-            if (e.getMessage().contains("timeout")) {
-                terminal.println(Constants.BROWSE_TIMEOUT);
-                return null;
-            }
-            terminal.println(e.getMessage());
-            Util.printError(terminal, e.getMessage());
-            return null;
-        }
+        final ResponseStatus result = browseJobLog(params[1]);
         if (!result.isStatus()) {
             return result;
         }

--- a/src/main/java/zos/shell/commands/Terminate.java
+++ b/src/main/java/zos/shell/commands/Terminate.java
@@ -6,6 +6,7 @@ import zos.shell.config.MvsConsoles;
 import zos.shell.dto.ResponseStatus;
 import zos.shell.utility.Util;
 import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosconsole.input.IssueConsoleParams;
 import zowe.client.sdk.zosconsole.method.IssueConsole;
 import zowe.client.sdk.zosconsole.response.ConsoleResponse;
@@ -57,8 +58,9 @@ public class Terminate {
             }
             // remove last newline i.e. \n
             return new ResponseStatus(result.substring(0, result.length() - 1), true);
-        } catch (Exception e) {
-            return new ResponseStatus(Util.getErrorMsg(e.getMessage()), false);
+        } catch (ZosmfRequestException e) {
+            final String errMsg = Util.getResponsePhrase(e.getResponse());
+            return new ResponseStatus((errMsg != null ? errMsg : e.getMessage()), false);
         }
     }
 

--- a/src/main/java/zos/shell/commands/Touch.java
+++ b/src/main/java/zos/shell/commands/Touch.java
@@ -6,6 +6,7 @@ import zos.shell.Constants;
 import zos.shell.dto.Member;
 import zos.shell.dto.ResponseStatus;
 import zos.shell.utility.Util;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosfiles.dsn.methods.DsnWrite;
 
 public class Touch {
@@ -34,7 +35,7 @@ public class Touch {
         var foundExistingMember = false;
         try {
             foundExistingMember = members.getMembers(dataSet).stream().anyMatch(m -> m.equalsIgnoreCase(member));
-        } catch (Exception ignored) {
+        } catch (ZosmfRequestException ignored) {
         }
 
         try {
@@ -43,8 +44,9 @@ public class Touch {
             } else {
                 return new ResponseStatus(member + " already exists.", true);
             }
-        } catch (Exception e) {
-            return new ResponseStatus(Util.getErrorMsg(e.getMessage()), true);
+        } catch (ZosmfRequestException e) {
+            final String errMsg = Util.getResponsePhrase(e.getResponse());
+            return new ResponseStatus((errMsg != null ? errMsg : e.getMessage()), false);
         }
 
         return new ResponseStatus(member + " successfully created.", true);

--- a/src/main/java/zos/shell/commands/TsoCommand.java
+++ b/src/main/java/zos/shell/commands/TsoCommand.java
@@ -3,7 +3,9 @@ package zos.shell.commands;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zos.shell.dto.ResponseStatus;
+import zos.shell.utility.Util;
 import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zostso.method.IssueTso;
 import zowe.client.sdk.zostso.response.IssueResponse;
 
@@ -22,7 +24,7 @@ public class TsoCommand {
         this.accountNumber = accountNumber;
     }
 
-    private IssueResponse execute(String command) throws Exception {
+    private IssueResponse execute(String command) throws ZosmfRequestException {
         LOG.debug("*** execute ***");
         return issueTso.issueCommand(accountNumber, command);
     }
@@ -36,17 +38,14 @@ public class TsoCommand {
             command = m.group(1);
         }
 
-        IssueResponse response = null;
-        var errMsg = "";
+        IssueResponse response;
         try {
             response = execute(command);
-        } catch (Exception e) {
-            errMsg = e.getMessage();
+        } catch (ZosmfRequestException e) {
+            final String errMsg = Util.getResponsePhrase(e.getResponse());
+            return new ResponseStatus((errMsg != null ? errMsg : e.getMessage()), false);
         }
 
-        if (response == null) {
-            return new ResponseStatus(errMsg, false);
-        }
         return new ResponseStatus(response.getCommandResponses().orElse("no response"), true);
     }
 

--- a/src/main/java/zos/shell/commands/Ussh.java
+++ b/src/main/java/zos/shell/commands/Ussh.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zowe.client.sdk.core.SshConnection;
 import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.zosuss.exception.IssueUssException;
 import zowe.client.sdk.zosuss.method.IssueUss;
 
 import java.util.Map;
@@ -34,7 +35,7 @@ public class Ussh {
             final var issueUss = new IssueUss(sshConnection);
             // 10000 is the timeout value in milliseconds
             terminal.println(issueUss.issueCommand(command, 10000));
-        } catch (Exception e) {
+        } catch (IssueUssException e) {
             terminal.println(e.getMessage());
         }
     }

--- a/src/main/java/zos/shell/dto/Member.java
+++ b/src/main/java/zos/shell/dto/Member.java
@@ -1,5 +1,6 @@
 package zos.shell.dto;
 
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosfiles.dsn.input.ListParams;
 import zowe.client.sdk.zosfiles.dsn.methods.DsnList;
 
@@ -15,7 +16,7 @@ public class Member {
         this.dsnList = dsnList;
     }
 
-    public List<String> getMembers(String dataSet) throws Exception {
+    public List<String> getMembers(String dataSet) throws ZosmfRequestException {
         List<zowe.client.sdk.zosfiles.dsn.response.Member> members = dsnList.getMembers(dataSet, params);
         final var memberNames = new ArrayList<String>();
         members.forEach(m -> memberNames.add(m.getMember().orElse("")));

--- a/src/main/java/zos/shell/future/FutureBrowseJob.java
+++ b/src/main/java/zos/shell/future/FutureBrowseJob.java
@@ -1,5 +1,6 @@
 package zos.shell.future;
 
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosjobs.input.JobFile;
 import zowe.client.sdk.zosjobs.methods.JobGet;
 
@@ -22,7 +23,7 @@ public class FutureBrowseJob implements Callable<StringBuilder> {
         files.forEach(file -> {
             try {
                 str.append(List.of(jobGet.getSpoolContent(file)));
-            } catch (Exception ignored) {
+            } catch (ZosmfRequestException ignored) {
             }
         });
         return str;

--- a/src/main/java/zos/shell/utility/DirectorySetup.java
+++ b/src/main/java/zos/shell/utility/DirectorySetup.java
@@ -14,7 +14,7 @@ public class DirectorySetup {
     private String directoryPath;
     private String fileNamePath;
 
-    public void initialize(String directoryName, String fileName) throws Exception {
+    public void initialize(String directoryName, String fileName) {
         LOG.debug("*** initialize ***");
         if (SystemUtils.IS_OS_WINDOWS) {
             directoryPath = DIRECTORY_PATH_WINDOWS + directoryName;
@@ -23,7 +23,7 @@ public class DirectorySetup {
             directoryPath = DIRECTORY_PATH_MAC + directoryName;
             fileNamePath = directoryPath + "/" + fileName;
         } else {
-            throw new Exception(Constants.OS_ERROR);
+            throw new IllegalStateException(Constants.OS_ERROR);
         }
     }
 

--- a/src/main/java/zos/shell/utility/Util.java
+++ b/src/main/java/zos/shell/utility/Util.java
@@ -8,6 +8,8 @@ import zos.shell.Constants;
 import zos.shell.dto.DataSetMember;
 import zos.shell.dto.Member;
 import zowe.client.sdk.core.ZosConnection;
+import zowe.client.sdk.rest.Response;
+import zowe.client.sdk.rest.exception.ZosmfRequestException;
 import zowe.client.sdk.zosfiles.dsn.methods.DsnList;
 
 import java.io.IOException;
@@ -131,8 +133,9 @@ public class Util {
         final List<String> members;
         try {
             members = member.getMembers(dataSet);
-        } catch (Exception e) {
-            Util.printError(terminal, e.getMessage());
+        } catch (ZosmfRequestException e) {
+            final String errMsg = Util.getResponsePhrase(e.getResponse());
+            terminal.println((errMsg != null ? errMsg : e.getMessage()));
             return new ArrayList<>();
         }
         return members;
@@ -209,4 +212,10 @@ public class Util {
         }
     }
 
+    public static String getResponsePhrase(Response response) {
+        if (response == null || response.getResponsePhrase().isEmpty()) {
+            return null;
+        }
+        return response.getResponsePhrase().get().toString();
+    }
 }

--- a/src/main/java/zos/shell/utility/Util.java
+++ b/src/main/java/zos/shell/utility/Util.java
@@ -65,35 +65,6 @@ public class Util {
         return isSegment(memberName.toUpperCase(Locale.ROOT));
     }
 
-    public static void printError(TextTerminal<?> terminal, String message) {
-        LOG.debug("*** printError ***");
-        if (message.contains("Not Found")) {
-            final var index = message.indexOf("Not Found");
-            final var msg = message.substring(index);
-            terminal.println(msg);
-        } else if (message.contains(Constants.CONNECTION_REFUSED)) {
-            terminal.println(Constants.SEVERE_ERROR);
-        } else if (message.contains("dataSetName not specified")) {
-            terminal.println(Constants.DATASET_NOT_SPECIFIED);
-        } else {
-            terminal.println(message);
-        }
-    }
-
-    public static String getErrorMsg(String message) {
-        LOG.debug("*** getErrorMsg ***");
-        if (message.contains("Not Found")) {
-            final var index = message.indexOf("Not Found");
-            return message.substring(index);
-        } else if (message.contains(Constants.CONNECTION_REFUSED)) {
-            return Constants.SEVERE_ERROR;
-        } else if (message.contains("dataSetName not specified")) {
-            return Constants.DATASET_NOT_SPECIFIED;
-        } else {
-            return message;
-        }
-    }
-
     public static boolean isStrNum(String strNum) {
         LOG.debug("*** isStrNum ***");
         try {


### PR DESCRIPTION
PR provides following updates:

- Fixed bug where mvs console command does not reflect console name value usage. 
- Simplify exception handling. 
- Implement new ZosmfRequestException exception handling. 
- Remove most usage of generic 'Exception' statements and replace with more specific exception types.
- Fixed duplicate message of Constants.OS_ERROR included in exception error. 
- Rely on Response object messaging to the end user from ZosmfRequestException for error states. 

This PR provides support for zowe client java sdk version 2.1.1+. 

Made changes associated with SDK version 2.2.0. Updated pom file with the removal of redundant dependencies and added SLFJ4 binding dependency which is no longer included in the SDK. 

Fixed an issue where logging output to the console was not working. Updates to the pom fixed it. 