### PR TITLE
Improve authentication handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The shell performs the following Linux like commands:
     set <arg>               - set environment variable with arg value in the following format: key=value
     touch <arg>             - create empty member if does not exist, arg represents a member or dataset(member)
     uname                   - show current connected host name
+    usermod <arg>           - modify username or password of current connection, arg can be -u or -p"
     vi <arg>                - where arg is a sequential dataset or member name, arg will be downloaded 
                               and displayed for editing, use save command to save changes  
     whoami                  - show current connected user name

--- a/README.md
+++ b/README.md
@@ -150,14 +150,18 @@ You can override the default file name and its location by setting the following
   
 The configuration file consists of JSON data. The configuration JSON string is defined as a JSON array structure. The array will consist of one or more profile(s).
   
-A profile is a one-to-one relationship of Profile.java file within the project. It contains variables as a placeholder for configuration information, such as z/OSMF and ssh connection information and properties to control the Window environment.  
+A profile is a one-to-one relationship of Profile.java file within the project. It contains variables as a placeholder for configuration information, such as z/OSMF and SSH connection information and properties to control the Window environment.  
     
-In addition, each profile contains path variable to control location for download directory.  
-
+In addition, each profile contains path variable to control location for the download directory.  
+  
 The first JSON array entry in the example below shows all the attributes defined to be read by the application.  
   
-The other JSON array entries shows that you don't need to specify all attributes and its values. The attributes most critical are those that specify a z/OSMF connection: hostname, zosmfport, username, and password.  
-  
+The other JSON array entries shows that you don't need to specify all attributes and its values. The attributes most critical are those that specify a z/OSMF connection: hostname and zosmfport.    
+   
+The username and password entries are optional. It is recommended to not specify those settings. When not specified, the application will prompt end user for username and password for the current connection.   
+    
+For further details on username and password usage see [here](https://github.com/Zowe-Java-SDK/ZosShell/issues/178)  
+    
 Example of config.json:  
 
     [
@@ -165,8 +169,8 @@ Example of config.json:
             "hostname": "xxxxxxxxx",
             "zosmfport": "xxxx",
             "sshport" : "xxxx",
-            "username": "xxxxx",
-            "password": "xxxxxx",
+            "username": "",
+            "password": "",
             "downloadpath": "/ZosShell",
             "consolename": "",
             "window": {
@@ -180,8 +184,6 @@ Example of config.json:
             "hostname": "xxxxxxxxx",
             "zosmfport": "xxxx",
             "sshport" : "xxxx",
-            "username": "xxxxx",
-            "password": "xxxxxx",
             "downloadpath": "C:\\ZosShell3",
             "consolename": "",
             "window": {}		
@@ -190,8 +192,6 @@ Example of config.json:
             "hostname": "xxxxxxxxx",
             "zosmfport": "xxxx",
             "sshport" : "xxxx",
-            "username": "xxxxx",
-            "password": "xxxxxx",
             "downloadpath": "C:\\ZosShell",
             "consolename": "",
             "window": {}		

--- a/src/main/java/zos/shell/ZosShell.java
+++ b/src/main/java/zos/shell/ZosShell.java
@@ -90,7 +90,7 @@ public class ZosShell implements BiConsumer<TextIO, RunnerData> {
         var currConnection = ConnSingleton.getInstance().getCurrZosConnection();
         var currSshConnection = ConnSingleton.getInstance().getCurrSshConnection();
 
-        // display information on initial first connection defined and set for usage
+        // setup initial first connection definition and prompt for username and password if applicable.
         try {
             var host = currConnection.getHost();
             var zosmfport = currConnection.getZosmfPort();
@@ -102,20 +102,9 @@ public class ZosShell implements BiConsumer<TextIO, RunnerData> {
             }
 
             if (username.isBlank() || password.isBlank()) {
-                TerminalSingleton.getInstance().setDisableKeys(true);
                 terminal.println("Enter username and password for host " + host);
-                username = TerminalSingleton.getInstance()
-                        .getMainTextIO()
-                        .newStringInputReader()
-                        .withMaxLength(80)
-                        .read("username:");
-                password = TerminalSingleton.getInstance()
-                        .getMainTextIO()
-                        .newStringInputReader()
-                        .withMaxLength(80)
-                        .withInputMasking(true)
-                        .read("password:");
-                TerminalSingleton.getInstance().setDisableKeys(false);
+                username = PromptUtil.getPromptInfo("username:", false);
+                password = PromptUtil.getPromptInfo("password:", true);
 
                 currConnection = new ZosConnection(host, zosmfport, username, password);
 

--- a/src/main/java/zos/shell/ZosShell.java
+++ b/src/main/java/zos/shell/ZosShell.java
@@ -102,6 +102,7 @@ public class ZosShell implements BiConsumer<TextIO, RunnerData> {
             }
 
             if (username.isBlank() || password.isBlank()) {
+                TerminalSingleton.getInstance().setDisableKeys(true);
                 terminal.println("Enter username and password for host " + host);
                 username = TerminalSingleton.getInstance()
                         .getMainTextIO()
@@ -114,6 +115,7 @@ public class ZosShell implements BiConsumer<TextIO, RunnerData> {
                         .withMaxLength(80)
                         .withInputMasking(true).
                         read("password:");
+                TerminalSingleton.getInstance().setDisableKeys(false);
 
                 currConnection = new ZosConnection(host, zosmfport, username, password);
 

--- a/src/main/java/zos/shell/ZosShell.java
+++ b/src/main/java/zos/shell/ZosShell.java
@@ -55,7 +55,7 @@ public class ZosShell implements BiConsumer<TextIO, RunnerData> {
 
         // initialize ConnSingleton object
         var connSingleton = ConnSingleton.getInstance();
-        connSingleton.setCurrZosConnection(ConfigSingleton.getInstance().getZosConnectionByIndex(0));
+        connSingleton.setCurrZosConnection(ConfigSingleton.getInstance().getZosConnectionByIndex(0), 0);
         connSingleton.setCurrSshConnection(ConfigSingleton.getInstance().getSshConnectionByIndex(0));
         var title = Constants.APP_TITLE + " - " + connSingleton.getCurrSshConnection().getHost().toUpperCase();
         TerminalSingleton.getInstance().getMainTerminal().setPaneTitle(title);
@@ -110,7 +110,7 @@ public class ZosShell implements BiConsumer<TextIO, RunnerData> {
 
                 ValidateUtils.checkConnection(currConnection);
                 ConfigSingleton.getInstance().setZosConnectionByIndex(currConnection, 0);
-                ConnSingleton.getInstance().setCurrZosConnection(currConnection);
+                ConnSingleton.getInstance().setCurrZosConnection(currConnection, 0);
                 currSshConnection = new SshConnection(host, currSshConnection.getPort(), username, password);
                 ConfigSingleton.getInstance().setSshConnectionByIndex(currSshConnection, 0);
                 ConnSingleton.getInstance().setCurrSshConnection(currSshConnection);

--- a/src/main/java/zos/shell/ZosShell.java
+++ b/src/main/java/zos/shell/ZosShell.java
@@ -113,8 +113,8 @@ public class ZosShell implements BiConsumer<TextIO, RunnerData> {
                         .getMainTextIO()
                         .newStringInputReader()
                         .withMaxLength(80)
-                        .withInputMasking(true).
-                        read("password:");
+                        .withInputMasking(true)
+                        .read("password:");
                 TerminalSingleton.getInstance().setDisableKeys(false);
 
                 currConnection = new ZosConnection(host, zosmfport, username, password);

--- a/src/main/java/zos/shell/command/CommandRouter.java
+++ b/src/main/java/zos/shell/command/CommandRouter.java
@@ -122,10 +122,17 @@ public class CommandRouter {
                 if (isParamsExceeded(2, params)) {
                     return;
                 }
+                int changeIndex;
+                try {
+                    changeIndex = Integer.parseInt(params[1]);
+                } catch (NumberFormatException e) {
+                    terminal.println(Constants.INVALID_COMMAND);
+                    return;
+                }
                 var previousCurrConnection = currConnection;
                 var changeConnController = controllerContainer.getChangeConnController(terminal);
                 currConnection = changeConnController.changeZosConnection(currConnection, params);
-                ConnSingleton.getInstance().setCurrZosConnection(currConnection);
+                ConnSingleton.getInstance().setCurrZosConnection(currConnection, changeIndex);
                 currSshConnection = changeConnController.changeSshConnection(currSshConnection, params);
                 ConnSingleton.getInstance().setCurrSshConnection(currSshConnection);
                 if (previousCurrConnection != currConnection) {
@@ -620,6 +627,9 @@ public class CommandRouter {
                 if (isParamsMissing(1, params)) {
                     return;
                 }
+                if (isParamsExceeded(2, params)) {
+                    return;
+                }
                 String acctNum = controllerContainer.getEnvVariableController().getValueByEnv("ACCTNUM");
                 StringBuilder tsoCommandCandidate = getCommandFromParams(params);
                 long tsoCommandCount = tsoCommandCandidate.codePoints().filter(ch -> ch == '\"').count();
@@ -637,6 +647,19 @@ public class CommandRouter {
                 var unameController = controllerContainer.getUnameController(currConnection, timeout);
                 String unameResult = unameController.uname(currConnection);
                 terminal.println(unameResult);
+                break;
+            case "usermod":
+                if (isParamsMissing(1, params)) {
+                    return;
+                }
+                if (isParamsExceeded(2, params)) {
+                    return;
+                }
+                var usermodController = controllerContainer.getUsermodController(currConnection,
+                        ConnSingleton.getInstance().getCurrZosConnectionIndex());
+                var flag = params[1];
+                String usermodResult = usermodController.change(flag);
+                terminal.println(usermodResult);
                 break;
             case "ussh":
                 if (isParamsMissing(1, params)) {

--- a/src/main/java/zos/shell/command/CommandRouter.java
+++ b/src/main/java/zos/shell/command/CommandRouter.java
@@ -122,13 +122,18 @@ public class CommandRouter {
                 if (isParamsExceeded(2, params)) {
                     return;
                 }
+                var previousCurrConnection = currConnection;
                 var changeConnController = controllerContainer.getChangeConnController(terminal);
                 currConnection = changeConnController.changeZosConnection(currConnection, params);
                 ConnSingleton.getInstance().setCurrZosConnection(currConnection);
                 currSshConnection = changeConnController.changeSshConnection(currSshConnection, params);
                 ConnSingleton.getInstance().setCurrSshConnection(currSshConnection);
-                var msg = "Connected to " + currConnection.getHost() + " as user " + currConnection.getUser() + ".";
-                terminal.println(msg);
+                if (previousCurrConnection != currConnection) {
+                    var msg = String.format("Connection changed:\nhost:%s\nuser:%s\nzosmfport:%s\nsshport:%s",
+                            currConnection.getHost(), currConnection.getUser(), currConnection.getZosmfPort(),
+                            currSshConnection.getPort());
+                    terminal.println(msg);
+                }
                 TerminalSingleton.getInstance().getMainTerminal()
                         .setPaneTitle(Constants.APP_TITLE + " - " + currConnection.getHost().toUpperCase());
                 break;

--- a/src/main/java/zos/shell/command/CommandRouter.java
+++ b/src/main/java/zos/shell/command/CommandRouter.java
@@ -627,9 +627,6 @@ public class CommandRouter {
                 if (isParamsMissing(1, params)) {
                     return;
                 }
-                if (isParamsExceeded(2, params)) {
-                    return;
-                }
                 String acctNum = controllerContainer.getEnvVariableController().getValueByEnv("ACCTNUM");
                 StringBuilder tsoCommandCandidate = getCommandFromParams(params);
                 long tsoCommandCount = tsoCommandCandidate.codePoints().filter(ch -> ch == '\"').count();

--- a/src/main/java/zos/shell/controller/UsermodController.java
+++ b/src/main/java/zos/shell/controller/UsermodController.java
@@ -1,0 +1,31 @@
+package zos.shell.controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import zos.shell.constants.Constants;
+import zos.shell.service.usermod.UsermodService;
+
+public class UsermodController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UsermodController.class);
+
+    private final UsermodService usermodService;
+
+    public UsermodController(final UsermodService usermodService) {
+        LOG.debug("*** UsermodController ***");
+        this.usermodService = usermodService;
+    }
+
+    public String change(final String flag) {
+        LOG.debug("*** change ***");
+        if ("-u".equalsIgnoreCase(flag)) {
+            return usermodService.changeUsername();
+        }
+        if ("-p".equalsIgnoreCase(flag)) {
+            return usermodService.changePassword();
+        } else {
+            return Constants.INVALID_COMMAND;
+        }
+    }
+
+}

--- a/src/main/java/zos/shell/controller/container/ControllerFactoryContainer.java
+++ b/src/main/java/zos/shell/controller/container/ControllerFactoryContainer.java
@@ -34,6 +34,7 @@ import zos.shell.service.omvs.SshService;
 import zos.shell.service.rename.RenameService;
 import zos.shell.service.search.SearchCacheService;
 import zos.shell.service.tso.TsoService;
+import zos.shell.service.usermod.UsermodService;
 import zowe.client.sdk.core.SshConnection;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.zosconsole.method.IssueConsole;
@@ -501,6 +502,12 @@ public class ControllerFactoryContainer {
             this.unameDependencyContainer = new DependencyCacheContainer(connection, timeout);
         }
         return this.unameController;
+    }
+
+    public UsermodController getUsermodController(final ZosConnection connection, final int index) {
+        LOG.debug("*** getUsermodController ***");
+        var usermodService = new UsermodService(connection, index);
+        return new UsermodController(usermodService);
     }
 
     public UssController getUssController(final SshConnection connection) {

--- a/src/main/java/zos/shell/service/autocomplete/SearchCommandService.java
+++ b/src/main/java/zos/shell/service/autocomplete/SearchCommandService.java
@@ -12,8 +12,8 @@ public final class SearchCommandService {
     private static final String[] commands = new String[]{"browsejob", "cancel", "cat", "cd", "change", "clear",
             "color", "connections", "count", "copy", "download", "downloadjob", "end", "env", "files", "grep",
             "help", "history", "hostname", "ls", "mkdir", "mvs", "purge", "ps", "pwd", "rename", "rm", "rn", "save",
-            "search", "set", "stop", "submit", "tail", "timeout", "touch", "tso", "uname", "ussh", "vi", "visited",
-            "whoami"};
+            "search", "set", "stop", "submit", "tail", "timeout", "touch", "tso", "uname", "usermod", "ussh", "vi",
+            "visited", "whoami"};
 
     private final TriePreFix dictionary = new TriePreFix(commands);
 

--- a/src/main/java/zos/shell/service/change/ChangeConnService.java
+++ b/src/main/java/zos/shell/service/change/ChangeConnService.java
@@ -52,6 +52,7 @@ public class ChangeConnService {
             return zosConnectionByIndex;
         }
 
+        TerminalSingleton.getInstance().setDisableKeys(true);
         terminal.println("Enter username and password for host " + host);
         username = TerminalSingleton.getInstance()
                 .getMainTextIO()
@@ -64,6 +65,7 @@ public class ChangeConnService {
                 .withMaxLength(80)
                 .withInputMasking(true).
                 read("password:");
+        TerminalSingleton.getInstance().setDisableKeys(false);
         ConfigSingleton.getInstance().updateWindowSittings(terminal);
         configSingleton.setZosConnectionByIndex(new ZosConnection(host, zosmfport, username, password), index);
         return configSingleton.getZosConnectionByIndex(index);

--- a/src/main/java/zos/shell/service/change/ChangeConnService.java
+++ b/src/main/java/zos/shell/service/change/ChangeConnService.java
@@ -63,8 +63,8 @@ public class ChangeConnService {
                 .getMainTextIO()
                 .newStringInputReader()
                 .withMaxLength(80)
-                .withInputMasking(true).
-                read("password:");
+                .withInputMasking(true)
+                .read("password:");
         TerminalSingleton.getInstance().setDisableKeys(false);
         ConfigSingleton.getInstance().updateWindowSittings(terminal);
         configSingleton.setZosConnectionByIndex(new ZosConnection(host, zosmfport, username, password), index);

--- a/src/main/java/zos/shell/service/change/ChangeConnService.java
+++ b/src/main/java/zos/shell/service/change/ChangeConnService.java
@@ -4,9 +4,9 @@ import org.beryx.textio.TextTerminal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zos.shell.constants.Constants;
-import zos.shell.singleton.TerminalSingleton;
 import zos.shell.singleton.configuration.ConfigSingleton;
 import zos.shell.singleton.configuration.record.ConfigSettings;
+import zos.shell.utility.PromptUtil;
 import zowe.client.sdk.core.SshConnection;
 import zowe.client.sdk.core.ZosConnection;
 
@@ -52,20 +52,9 @@ public class ChangeConnService {
             return zosConnectionByIndex;
         }
 
-        TerminalSingleton.getInstance().setDisableKeys(true);
         terminal.println("Enter username and password for host " + host);
-        username = TerminalSingleton.getInstance()
-                .getMainTextIO()
-                .newStringInputReader()
-                .withMaxLength(80)
-                .read("username:");
-        password = TerminalSingleton.getInstance()
-                .getMainTextIO()
-                .newStringInputReader()
-                .withMaxLength(80)
-                .withInputMasking(true)
-                .read("password:");
-        TerminalSingleton.getInstance().setDisableKeys(false);
+        username = PromptUtil.getPromptInfo("username:", false);
+        password = PromptUtil.getPromptInfo("password:", true);
         ConfigSingleton.getInstance().updateWindowSittings(terminal);
         configSingleton.setZosConnectionByIndex(new ZosConnection(host, zosmfport, username, password), index);
         return configSingleton.getZosConnectionByIndex(index);

--- a/src/main/java/zos/shell/service/help/HelpService.java
+++ b/src/main/java/zos/shell/service/help/HelpService.java
@@ -67,6 +67,7 @@ public class HelpService {
             "touch <arg>             - create empty member if does not exist, arg represents a member or dataset(member)",
             "tso <arg>               - execute a tso command where arg is a command string within double quotes",
             "uname                   - show current connected host name",
+            "usermod <arg>           - modify username or password of current connection, arg can be -u or -p",
             "ussh <arg>              - execute USS/UNIX command via SSH connection where arg is a command string within double quotes",
             "vi <arg>                - where arg is a sequential dataset or member name, arg will be downloaded",
             "                          and displayed for editing, use save command to save changes",

--- a/src/main/java/zos/shell/service/usermod/UsermodService.java
+++ b/src/main/java/zos/shell/service/usermod/UsermodService.java
@@ -1,0 +1,57 @@
+package zos.shell.service.usermod;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import zos.shell.singleton.ConnSingleton;
+import zos.shell.singleton.configuration.ConfigSingleton;
+import zos.shell.utility.PromptUtil;
+import zowe.client.sdk.core.SshConnection;
+import zowe.client.sdk.core.ZosConnection;
+
+public class UsermodService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UsermodService.class);
+
+    private final String host;
+    private final String zosmfPort;
+    private final String username;
+    private final String password;
+    private final int sshPort;
+
+    private final int index;
+
+    public UsermodService(final ZosConnection connection, final int index) {
+        LOG.debug("*** UsermodService ***");
+        this.host = connection.getHost();
+        this.zosmfPort = connection.getZosmfPort();
+        this.username = connection.getUser();
+        this.password = connection.getPassword();
+        this.sshPort = ConfigSingleton.getInstance().getSshConnectionByIndex(index).getPort();
+        this.index = index;
+    }
+
+    public String changePassword() {
+        LOG.debug("*** changePassword ***");
+        var password = PromptUtil.getPromptInfo("password:", true);
+        var zosConnection = new ZosConnection(this.host, this.zosmfPort, this.username, password);
+        var sshConnection = new SshConnection(this.host, this.sshPort, this.username, password);
+        ConfigSingleton.getInstance().setZosConnectionByIndex(zosConnection, index);
+        ConnSingleton.getInstance().setCurrZosConnection(zosConnection, index);
+        ConfigSingleton.getInstance().setSshConnectionByIndex(sshConnection, index);
+        ConnSingleton.getInstance().setCurrSshConnection(sshConnection);
+        return "password changed";
+    }
+
+    public String changeUsername() {
+        LOG.debug("*** changeUsername ***");
+        var username = PromptUtil.getPromptInfo("username:", false);
+        var zosConnection = new ZosConnection(this.host, this.zosmfPort, username, this.password);
+        var sshConnection = new SshConnection(this.host, this.sshPort, username, this.password);
+        ConfigSingleton.getInstance().setZosConnectionByIndex(zosConnection, index);
+        ConnSingleton.getInstance().setCurrZosConnection(zosConnection, index);
+        ConfigSingleton.getInstance().setSshConnectionByIndex(sshConnection, index);
+        ConnSingleton.getInstance().setCurrSshConnection(sshConnection);
+        return "username changed";
+    }
+
+}

--- a/src/main/java/zos/shell/singleton/ConnSingleton.java
+++ b/src/main/java/zos/shell/singleton/ConnSingleton.java
@@ -11,6 +11,7 @@ public class ConnSingleton {
 
     private ZosConnection currZosConnection;
     private SshConnection currSshConnection;
+    private int connectionIndex;
 
     private static class Holder {
         private static final ConnSingleton instance = new ConnSingleton();
@@ -30,9 +31,10 @@ public class ConnSingleton {
         return currZosConnection;
     }
 
-    public void setCurrZosConnection(final ZosConnection currZosConnection) {
+    public void setCurrZosConnection(final ZosConnection currZosConnection, int index) {
         LOG.debug("*** setCurrZosConnection ***");
         this.currZosConnection = currZosConnection;
+        this.connectionIndex = index;
     }
 
     public SshConnection getCurrSshConnection() {
@@ -43,6 +45,11 @@ public class ConnSingleton {
     public void setCurrSshConnection(final SshConnection currSshConnection) {
         LOG.debug("*** setCurrSshConnection ***");
         this.currSshConnection = currSshConnection;
+    }
+
+    public int getCurrZosConnectionIndex() {
+        LOG.debug("*** getCurrZosConnectionIndex ***");
+        return connectionIndex;
     }
 
 }

--- a/src/main/java/zos/shell/singleton/configuration/ConfigSingleton.java
+++ b/src/main/java/zos/shell/singleton/configuration/ConfigSingleton.java
@@ -92,13 +92,23 @@ public class ConfigSingleton {
     private void createZosConnections() {
         LOG.debug("*** createZosConnections ***");
         profiles.forEach(profile -> zosConnections.add(new ZosConnection(profile.getHostname(),
-                profile.getZosmfport(), profile.getUsername(), profile.getPassword())));
+                profile.getZosmfport() != null ? profile.getZosmfport() : "0",
+                profile.getUsername() != null ? profile.getUsername() : "",
+                profile.getPassword() != null ? profile.getPassword() : "")));
     }
 
     private void createSshConnections() {
         LOG.debug("*** createSshConnections ***");
-        profiles.forEach(profile -> shhConnections.add(new SshConnection(profile.getHostname(),
-                Integer.parseInt(profile.getSshport()), profile.getUsername(), profile.getPassword())));
+        profiles.forEach(profile -> {
+            int sshport = 0;
+            try {
+                sshport = Integer.parseInt(profile.getSshport());
+            } catch (NumberFormatException ignored) {
+            }
+            shhConnections.add(new SshConnection(profile.getHostname(),
+                    sshport, profile.getUsername() != null ? profile.getUsername() : "",
+                    profile.getPassword() != null ? profile.getPassword() : ""));
+        });
     }
 
     public void updateWindowSittings(final TextTerminal<?> terminal) {
@@ -145,12 +155,20 @@ public class ConfigSingleton {
         return shhConnections.get(index);
     }
 
+    public void setSshConnectionByIndex(final SshConnection sshConnection, final int index) {
+        this.shhConnections.set(index, sshConnection);
+    }
+
     public ZosConnection getZosConnectionByIndex(int index) {
         LOG.debug("*** getZosConnectionByIndex ***");
         if (zosConnections.isEmpty()) {
             return null;
         }
         return zosConnections.get(index);
+    }
+
+    public void setZosConnectionByIndex(final ZosConnection zosConnection, final int index) {
+        this.zosConnections.set(index, zosConnection);
     }
 
     public ConfigSettings getConfigSettings() {

--- a/src/main/java/zos/shell/utility/PromptUtil.java
+++ b/src/main/java/zos/shell/utility/PromptUtil.java
@@ -3,6 +3,7 @@ package zos.shell.utility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zos.shell.constants.Constants;
+import zos.shell.singleton.TerminalSingleton;
 
 public final class PromptUtil {
 
@@ -16,6 +17,19 @@ public final class PromptUtil {
     public static String getPrompt() {
         LOG.debug("*** getPrompt ***");
         return Constants.DEFAULT_PROMPT;
+    }
+
+    public static String getPromptInfo(final String promptMsg, final boolean isMask) {
+        LOG.debug("*** getPrompt ***");
+        TerminalSingleton.getInstance().setDisableKeys(true);
+        var result = TerminalSingleton.getInstance()
+                .getMainTextIO()
+                .newStringInputReader()
+                .withMaxLength(80)
+                .withInputMasking(isMask)
+                .read(promptMsg);
+        TerminalSingleton.getInstance().setDisableKeys(false);
+        return result;
     }
 
 }


### PR DESCRIPTION
#178 

Secure password better so it can be specified and used without exposing it as plain text within the config.json file. 

Following PR request will change the way username and password is processed for each JSON profile connection.  

Proposal:

- Make username and password JSON config profile variables optional. 
- Prompt username and password at app startup for the first JSON profile hostname connection only if username and password are NOT already specified within the first JSON profile.  
- For each first "change" connection item command will prompt for username and password if not specified in its JSON profile.
- For each subsequent "change" connection command, it will use the cached username/password from its first prompt inputs.
- Add Linux like "usermod" command to allow end user to change username/password for the currently defined cache connection settings. 
- Disable special key combination features while prompting for username and password.

 