### PR TITLE
use builder pattern for dependency

### DIFF
--- a/src/main/java/zos/shell/controller/container/ControllerFactoryContainer.java
+++ b/src/main/java/zos/shell/controller/container/ControllerFactoryContainer.java
@@ -71,15 +71,14 @@ public class ControllerFactoryContainer {
                                                       final long timeout) {
         LOG.debug("*** getBrowseJobController ***");
         var controller = (BrowseJobController) controllers.get(ContainerType.Name.BROWSE_JOB);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.BROWSE_JOB);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, isAll, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.BROWSE_JOB);
+        var newDependency = new Dependency.Builder().zosConnection(connection).toggle(isAll).timeout(timeout).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var jobGet = new JobGet(connection);
             var service = new BrowseLogService(jobGet, isAll, timeout);
             controller = new BrowseJobController(service, this.envVariableController);
-            dependencyCacheContainer = new Dependency(connection, isAll, timeout);
             this.controllers.put(ContainerType.Name.BROWSE_JOB, controller);
-            this.dependencies.put(ContainerType.Name.BROWSE_JOB, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.BROWSE_JOB, newDependency);
         }
         return controller;
     }
@@ -87,15 +86,14 @@ public class ControllerFactoryContainer {
     public CancelController getCancelController(final ZosConnection connection, final long timeout) {
         LOG.debug("*** getCancelController ***");
         var controller = (CancelController) controllers.get(ContainerType.Name.CANCEL);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.CANCEL);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, false, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.CANCEL);
+        var newDependency = new Dependency.Builder().zosConnection(connection).timeout(timeout).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var issueConsole = new IssueConsole(connection);
             var service = new TerminateService(issueConsole, timeout);
             controller = new CancelController(service, ConfigSingleton.getInstance(), this.envVariableController);
-            dependencyCacheContainer = new Dependency(connection, timeout);
             this.controllers.put(ContainerType.Name.CANCEL, controller);
-            this.dependencies.put(ContainerType.Name.CANCEL, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.CANCEL, newDependency);
         }
         return controller;
     }
@@ -114,14 +112,13 @@ public class ControllerFactoryContainer {
     public ChangeDirController getChangeDirController(final ZosConnection connection) {
         LOG.debug("*** getChangeDirController ***");
         var controller = (ChangeDirController) controllers.get(ContainerType.Name.CHANGE_DIRECTORY);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.CHANGE_DIRECTORY);
-        if (controller == null || dependencyCacheContainer != null &&
-                !dependencyCacheContainer.isZosConnectionSame(connection)) {
+        var dependency = dependencies.get(ContainerType.Name.CHANGE_DIRECTORY);
+        var newDependency = new Dependency.Builder().zosConnection(connection).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var service = new ChangeDirService();
             controller = new ChangeDirController(service);
-            dependencyCacheContainer = new Dependency(connection);
             this.controllers.put(ContainerType.Name.CHANGE_DIRECTORY, controller);
-            this.dependencies.put(ContainerType.Name.CHANGE_DIRECTORY, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.CHANGE_DIRECTORY, newDependency);
         }
         return controller;
     }
@@ -140,16 +137,15 @@ public class ControllerFactoryContainer {
     public ConcatController getConcatController(final ZosConnection connection, final long timeout) {
         LOG.debug("*** getConcatController ***");
         var controller = (ConcatController) controllers.get(ContainerType.Name.CONCAT);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.CONCAT);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.CONCAT);
+        var newDependency = new Dependency.Builder().zosConnection(connection).timeout(timeout).build();
+        if (controller == null || dependency != null && dependency.equals(newDependency)) {
             var dsnGet = new DsnGet(connection);
             var download = new Download(dsnGet, this.pathService, false);
             var service = new ConcatService(download, timeout);
             controller = new ConcatController(service);
-            dependencyCacheContainer = new Dependency(connection, timeout);
             this.controllers.put(ContainerType.Name.CONCAT, controller);
-            this.dependencies.put(ContainerType.Name.CONCAT, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.CONCAT, newDependency);
         }
         return controller;
     }
@@ -157,14 +153,13 @@ public class ControllerFactoryContainer {
     public ConsoleController getConsoleController(final ZosConnection connection, final long timeout) {
         LOG.debug("*** getConsoleController ***");
         var controller = (ConsoleController) controllers.get(ContainerType.Name.CONSOLE);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.CONSOLE);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.CONSOLE);
+        var newDependency = new Dependency.Builder().zosConnection(connection).timeout(timeout).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var service = new ConsoleService(connection, timeout);
             controller = new ConsoleController(service, ConfigSingleton.getInstance(), this.envVariableController);
-            dependencyCacheContainer = new Dependency(connection, timeout);
             this.controllers.put(ContainerType.Name.CONSOLE, controller);
-            this.dependencies.put(ContainerType.Name.CONSOLE, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.CONSOLE, newDependency);
         }
         return controller;
     }
@@ -172,14 +167,13 @@ public class ControllerFactoryContainer {
     public CopyController getCopyController(final ZosConnection connection, final long timeout) {
         LOG.debug("*** getCopyController ***");
         var controller = (CopyController) controllers.get(ContainerType.Name.COPY);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.COPY);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.COPY);
+        var newDependency = new Dependency.Builder().zosConnection(connection).timeout(timeout).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var service = new CopyService(connection, timeout);
             controller = new CopyController(service);
-            dependencyCacheContainer = new Dependency(connection, timeout);
             this.controllers.put(ContainerType.Name.COPY, controller);
-            this.dependencies.put(ContainerType.Name.COPY, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.COPY, newDependency);
         }
         return controller;
     }
@@ -187,15 +181,14 @@ public class ControllerFactoryContainer {
     public CountController getCountController(final ZosConnection connection, final long timeout) {
         LOG.debug("*** getCountController ***");
         var controller = (CountController) controllers.get(ContainerType.Name.COUNT);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.COUNT);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.COUNT);
+        var newDependency = new Dependency.Builder().zosConnection(connection).timeout(timeout).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var dsnList = new DsnList(connection);
             var service = new CountService(dsnList, timeout);
             controller = new CountController(service);
-            dependencyCacheContainer = new Dependency(connection, timeout);
             this.controllers.put(ContainerType.Name.COUNT, controller);
-            this.dependencies.put(ContainerType.Name.COUNT, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.COUNT, newDependency);
         }
         return controller;
     }
@@ -203,14 +196,13 @@ public class ControllerFactoryContainer {
     public DeleteController getDeleteController(final ZosConnection connection, final long timeout) {
         LOG.debug("*** getDeleteController ***");
         var controller = (DeleteController) controllers.get(ContainerType.Name.DELETE);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.DELETE);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.DELETE);
+        var newDependency = new Dependency.Builder().zosConnection(connection).timeout(timeout).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var service = new DeleteService(connection, timeout);
             controller = new DeleteController(service);
-            dependencyCacheContainer = new Dependency(connection, timeout);
             this.controllers.put(ContainerType.Name.DELETE, controller);
-            this.dependencies.put(ContainerType.Name.DELETE, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.DELETE, newDependency);
         }
         return controller;
     }
@@ -219,9 +211,9 @@ public class ControllerFactoryContainer {
                                                           final long timeout) {
         LOG.debug("*** getDownloadDsnController ***");
         var controller = (DownloadDsnController) controllers.get(ContainerType.Name.DELETE);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.DELETE);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, isBinary, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.DELETE);
+        var newDependency = new Dependency.Builder().zosConnection(connection).toggle(isBinary).timeout(timeout).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var downloadMemberService = new DownloadMemberService(connection, this.pathService, isBinary, timeout);
             var downloadPdsMemberService = new DownloadPdsMemberService(connection, this.pathService, isBinary, timeout);
             var downloadSeqDatasetService = new DownloadSeqDatasetService(connection, this.pathService, isBinary, timeout);
@@ -231,9 +223,8 @@ public class ControllerFactoryContainer {
                     new DownloadMemberListService(connection, isBinary, timeout), timeout);
             controller = new DownloadDsnController(downloadMemberService, downloadPdsMemberService,
                     downloadSeqDatasetService, downloadAllMembersService, downloadMembersService);
-            dependencyCacheContainer = new Dependency(connection, isBinary, timeout);
             this.controllers.put(ContainerType.Name.DELETE, controller);
-            this.dependencies.put(ContainerType.Name.DELETE, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.DELETE, newDependency);
         }
         return controller;
     }
@@ -242,15 +233,14 @@ public class ControllerFactoryContainer {
                                                           final long timeout) {
         LOG.debug("*** getDownloadJobController ***");
         var controller = (DownloadJobController) controllers.get(ContainerType.Name.DOWNLOAD_JOB);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.DOWNLOAD_JOB);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, isAll, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.DOWNLOAD_JOB);
+        var newDependency = new Dependency.Builder().zosConnection(connection).toggle(isAll).timeout(timeout).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var jobGet = new JobGet(connection);
             var service = new DownloadJobService(jobGet, this.pathService, isAll, timeout);
             controller = new DownloadJobController(service);
-            dependencyCacheContainer = new Dependency(connection, isAll, timeout);
             this.controllers.put(ContainerType.Name.DOWNLOAD_JOB, controller);
-            this.dependencies.put(ContainerType.Name.DOWNLOAD_JOB, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.DOWNLOAD_JOB, newDependency);
         }
         return controller;
     }
@@ -269,17 +259,16 @@ public class ControllerFactoryContainer {
     public EditController getEditController(final ZosConnection connection, final long timeout) {
         LOG.debug("*** getEditController ***");
         var controller = (EditController) controllers.get(ContainerType.Name.EDIT);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.EDIT);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.EDIT);
+        var newDependency = new Dependency.Builder().zosConnection(connection).timeout(timeout).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var dsnGet = new DsnGet(connection);
             var download = new Download(dsnGet, this.pathService, false);
             var checkSumService = new CheckSumService();
             var editService = new EditService(download, this.pathService, checkSumService, timeout);
             controller = new EditController(editService);
-            dependencyCacheContainer = new Dependency(connection, timeout);
             this.controllers.put(ContainerType.Name.EDIT, controller);
-            this.dependencies.put(ContainerType.Name.EDIT, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.EDIT, newDependency);
         }
         return controller;
     }
@@ -292,14 +281,13 @@ public class ControllerFactoryContainer {
     public GrepController getGrepController(final ZosConnection connection, final String target, final long timeout) {
         LOG.debug("*** getGrepController ***");
         var controller = (GrepController) controllers.get(ContainerType.Name.GREP);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.GREP);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, target, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.GREP);
+        var newDependency = new Dependency.Builder().zosConnection(connection).data(target).timeout(timeout).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var service = new GrepService(connection, this.pathService, target, timeout);
             controller = new GrepController(service);
-            dependencyCacheContainer = new Dependency(connection, target, timeout);
             this.controllers.put(ContainerType.Name.GREP, controller);
-            this.dependencies.put(ContainerType.Name.GREP, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.GREP, newDependency);
         }
         return controller;
     }
@@ -308,15 +296,14 @@ public class ControllerFactoryContainer {
                                                   final long timeout) {
         LOG.debug("*** getListingController ***");
         var controller = (ListingController) controllers.get(ContainerType.Name.LIST);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.LIST);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.LIST);
+        var newDependency = new Dependency.Builder().zosConnection(connection).timeout(timeout).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var dsnList = new DsnList(connection);
             var service = new ListingService(terminal, dsnList, timeout);
             controller = new ListingController(service);
-            dependencyCacheContainer = new Dependency(connection, timeout);
             this.controllers.put(ContainerType.Name.LIST, controller);
-            this.dependencies.put(ContainerType.Name.LIST, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.LIST, newDependency);
         }
         return controller;
     }
@@ -336,15 +323,14 @@ public class ControllerFactoryContainer {
                                                   final long timeout) {
         LOG.debug("*** getMakeDirController ***");
         var controller = (MakeDirController) controllers.get(ContainerType.Name.MAKE_DIR);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.MAKE_DIR);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.MAKE_DIR);
+        var newDependency = new Dependency.Builder().zosConnection(connection).timeout(timeout).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var dsnCreate = new DsnCreate(connection);
             var service = new MakeDirService(dsnCreate, timeout);
             controller = new MakeDirController(terminal, service);
-            dependencyCacheContainer = new Dependency(connection, timeout);
             this.controllers.put(ContainerType.Name.MAKE_DIR, controller);
-            this.dependencies.put(ContainerType.Name.MAKE_DIR, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.MAKE_DIR, newDependency);
         }
         return controller;
     }
@@ -352,14 +338,13 @@ public class ControllerFactoryContainer {
     public ProcessLstController getProcessLstController(final ZosConnection connection, final long timeout) {
         LOG.debug("*** getProcessLstController ***");
         var controller = (ProcessLstController) controllers.get(ContainerType.Name.PROCESS_LIST);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.PROCESS_LIST);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.PROCESS_LIST);
+        var newDependency = new Dependency.Builder().zosConnection(connection).timeout(timeout).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var service = new ProcessLstService(new JobGet(connection), timeout);
             controller = new ProcessLstController(service);
-            dependencyCacheContainer = new Dependency(connection, timeout);
             this.controllers.put(ContainerType.Name.PROCESS_LIST, controller);
-            this.dependencies.put(ContainerType.Name.PROCESS_LIST, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.PROCESS_LIST, newDependency);
         }
         return controller;
     }
@@ -367,16 +352,15 @@ public class ControllerFactoryContainer {
     public PurgeController getPurgeController(final ZosConnection connection, final long timeout) {
         LOG.debug("*** getPurgeController ***");
         var controller = (PurgeController) controllers.get(ContainerType.Name.PURGE);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.PURGE);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.PURGE);
+        var newDependency = new Dependency.Builder().zosConnection(connection).timeout(timeout).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var jobDelete = new JobDelete(connection);
             var jobGet = new JobGet(connection);
             var service = new PurgeService(jobDelete, jobGet, timeout);
             controller = new PurgeController(service);
-            dependencyCacheContainer = new Dependency(connection, timeout);
             this.controllers.put(ContainerType.Name.PURGE, controller);
-            this.dependencies.put(ContainerType.Name.PURGE, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.PURGE, newDependency);
         }
         return controller;
     }
@@ -384,14 +368,13 @@ public class ControllerFactoryContainer {
     public RenameController getRenameController(final ZosConnection connection, final long timeout) {
         LOG.debug("*** getRenameController ***");
         var controller = (RenameController) controllers.get(ContainerType.Name.RENAME);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.RENAME);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.RENAME);
+        var newDependency = new Dependency.Builder().zosConnection(connection).timeout(timeout).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var service = new RenameService(connection, timeout);
             controller = new RenameController(service);
-            dependencyCacheContainer = new Dependency(connection, timeout);
             this.controllers.put(ContainerType.Name.RENAME, controller);
-            this.dependencies.put(ContainerType.Name.RENAME, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.RENAME, newDependency);
         }
         return controller;
     }
@@ -399,15 +382,14 @@ public class ControllerFactoryContainer {
     public SaveController getSaveController(final ZosConnection connection, final long timeout) {
         LOG.debug("*** getSaveController ***");
         var controller = (SaveController) controllers.get(ContainerType.Name.SAVE);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.SAVE);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.SAVE);
+        var newDependency = new Dependency.Builder().zosConnection(connection).timeout(timeout).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var checkSumService = new CheckSumService();
             var service = new SaveService(new DsnWrite(connection), this.pathService, checkSumService, timeout);
             controller = new SaveController(service);
-            dependencyCacheContainer = new Dependency(connection, timeout);
             this.controllers.put(ContainerType.Name.SAVE, controller);
-            this.dependencies.put(ContainerType.Name.SAVE, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.SAVE, newDependency);
         }
         return controller;
     }
@@ -426,16 +408,14 @@ public class ControllerFactoryContainer {
     public StopController getStopController(final ZosConnection connection, final long timeout) {
         LOG.debug("*** getStopController ***");
         var controller = (StopController) controllers.get(ContainerType.Name.STOP);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.STOP);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.STOP);
+        var newDependency = new Dependency.Builder().zosConnection(connection).timeout(timeout).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var issueConsole = new IssueConsole(connection);
             var service = new TerminateService(issueConsole, timeout);
-            controller = new StopController(service,
-                    ConfigSingleton.getInstance(), this.envVariableController);
-            dependencyCacheContainer = new Dependency(connection, timeout);
+            controller = new StopController(service, ConfigSingleton.getInstance(), this.envVariableController);
             this.controllers.put(ContainerType.Name.STOP, controller);
-            this.dependencies.put(ContainerType.Name.STOP, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.STOP, newDependency);
         }
         return controller;
     }
@@ -443,15 +423,14 @@ public class ControllerFactoryContainer {
     public SubmitController getSubmitController(final ZosConnection connection, final long timeout) {
         LOG.debug("*** getSubmitController ***");
         var controller = (SubmitController) controllers.get(ContainerType.Name.SUBMIT);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.SUBMIT);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.SUBMIT);
+        var newDependency = new Dependency.Builder().zosConnection(connection).timeout(timeout).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var jobSubmit = new JobSubmit(connection);
             var service = new SubmitService(jobSubmit, timeout);
             controller = new SubmitController(service);
-            dependencyCacheContainer = new Dependency(connection, timeout);
             this.controllers.put(ContainerType.Name.SUBMIT, controller);
-            this.dependencies.put(ContainerType.Name.SUBMIT, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.SUBMIT, newDependency);
         }
         return controller;
     }
@@ -460,15 +439,14 @@ public class ControllerFactoryContainer {
                                             final long timeout) {
         LOG.debug("*** getTailController ***");
         var controller = (TailController) controllers.get(ContainerType.Name.TAIL);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.TAIL);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.TAIL);
+        var newDependency = new Dependency.Builder().zosConnection(connection).timeout(timeout).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var jobGet = new JobGet(connection);
             var service = new TailService(terminal, jobGet, timeout);
             controller = new TailController(service);
-            dependencyCacheContainer = new Dependency(connection, timeout);
             this.controllers.put(ContainerType.Name.TAIL, controller);
-            this.dependencies.put(ContainerType.Name.TAIL, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.TAIL, newDependency);
         }
         return controller;
     }
@@ -476,16 +454,15 @@ public class ControllerFactoryContainer {
     public TouchController getTouchController(final ZosConnection connection, final long timeout) {
         LOG.debug("*** getTouchController ***");
         var controller = (TouchController) controllers.get(ContainerType.Name.TOUCH);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.TOUCH);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.TOUCH);
+        var newDependency = new Dependency.Builder().zosConnection(connection).timeout(timeout).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var dsnWrite = new DsnWrite(connection);
             var dsnList = new DsnList(connection);
             var service = new TouchService(dsnWrite, dsnList, timeout);
             controller = new TouchController(service);
-            dependencyCacheContainer = new Dependency(connection, timeout);
             this.controllers.put(ContainerType.Name.TOUCH, controller);
-            this.dependencies.put(ContainerType.Name.TOUCH, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.TOUCH, newDependency);
         }
         return controller;
     }
@@ -493,15 +470,14 @@ public class ControllerFactoryContainer {
     public TsoController getTsoController(final ZosConnection connection, final long timeout) {
         LOG.debug("*** getTsoController ***");
         var controller = (TsoController) controllers.get(ContainerType.Name.TSO);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.TSO);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.TSO);
+        var newDependency = new Dependency.Builder().zosConnection(connection).timeout(timeout).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var issueTso = new IssueTso(connection);
             var service = new TsoService(issueTso, timeout);
             controller = new TsoController(service, ConfigSingleton.getInstance(), this.envVariableController);
-            dependencyCacheContainer = new Dependency(connection, timeout);
             this.controllers.put(ContainerType.Name.TSO, controller);
-            this.dependencies.put(ContainerType.Name.TSO, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.TSO, newDependency);
         }
         return controller;
     }
@@ -509,15 +485,14 @@ public class ControllerFactoryContainer {
     public UnameController getUnameController(final ZosConnection connection, final long timeout) {
         LOG.debug("*** getUnameController ***");
         var controller = (UnameController) controllers.get(ContainerType.Name.UNAME);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.UNAME);
-        if (controller == null || dependencyCacheContainer != null &&
-                dependencyCacheContainer.isValid(connection, timeout)) {
+        var dependency = dependencies.get(ContainerType.Name.UNAME);
+        var newDependency = new Dependency.Builder().zosConnection(connection).timeout(timeout).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var issueConsole = new IssueConsole(connection);
             var service = new UnameService(issueConsole, timeout);
             controller = new UnameController(service, ConfigSingleton.getInstance(), this.envVariableController);
-            dependencyCacheContainer = new Dependency(connection, timeout);
             this.controllers.put(ContainerType.Name.UNAME, controller);
-            this.dependencies.put(ContainerType.Name.UNAME, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.UNAME, newDependency);
         }
         return controller;
     }
@@ -536,14 +511,13 @@ public class ControllerFactoryContainer {
     public UssController getUssController(final SshConnection connection) {
         LOG.debug("*** getUssController ***");
         var controller = (UssController) controllers.get(ContainerType.Name.USS);
-        var dependencyCacheContainer = dependencies.get(ContainerType.Name.USS);
-        if (controller == null || dependencyCacheContainer != null &&
-                !(dependencyCacheContainer.isSshConnectionSame(connection))) {
+        var dependency = dependencies.get(ContainerType.Name.USS);
+        var newDependency = new Dependency.Builder().sshConnection(connection).build();
+        if (controller == null || dependency != null && !dependency.equals(newDependency)) {
             var service = new SshService(connection);
             controller = new UssController(service);
-            dependencyCacheContainer = new Dependency(connection);
             this.controllers.put(ContainerType.Name.USS, controller);
-            this.dependencies.put(ContainerType.Name.USS, dependencyCacheContainer);
+            this.dependencies.put(ContainerType.Name.USS, newDependency);
         }
         return controller;
     }

--- a/src/main/java/zos/shell/controller/container/Dependency.java
+++ b/src/main/java/zos/shell/controller/container/Dependency.java
@@ -5,85 +5,90 @@ import org.slf4j.LoggerFactory;
 import zowe.client.sdk.core.SshConnection;
 import zowe.client.sdk.core.ZosConnection;
 
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
+
 public class Dependency {
 
     private static final Logger LOG = LoggerFactory.getLogger(Dependency.class);
 
-    private ZosConnection zosConnection;
-    private SshConnection sshConnection;
-    private String data;
-    private boolean toggle;
-    private long timeout;
+    private final Optional<ZosConnection> zosConnection;
+    private final Optional<SshConnection> sshConnection;
+    private final Optional<String> data;
+    private final boolean toggle;
+    private final OptionalLong timeout;
 
-    public Dependency(final ZosConnection zosConnection, final long timeout) {
-        LOG.debug("*** DependencyContainer zosConnection timeout ***");
-        this.zosConnection = zosConnection;
-        this.timeout = timeout;
-    }
-
-    public Dependency(final ZosConnection zosConnection, final boolean toggle, final long timeout) {
-        LOG.debug("*** DependencyContainer zosConnection toggle timeout ***");
-        this.zosConnection = zosConnection;
-        this.toggle = toggle;
-        this.timeout = timeout;
-    }
-
-    public Dependency(final ZosConnection zosConnection) {
-        LOG.debug("*** DependencyContainer zosConnection ***");
-        this.zosConnection = zosConnection;
-    }
-
-    public Dependency(final SshConnection sshConnection) {
-        LOG.debug("*** DependencyContainer sshConnection ***");
-        this.sshConnection = sshConnection;
-    }
-
-    public Dependency(final ZosConnection zosConnection, final String data, final long timeout) {
-        LOG.debug("*** DependencyContainer zosConnection data timeout ***");
-        this.zosConnection = zosConnection;
-        if (data == null) {
-            this.data = "";
+    public Dependency(Builder builder) {
+        LOG.debug("*** Dependency ***");
+        this.zosConnection = Optional.ofNullable(builder.zosConnection);
+        this.sshConnection = Optional.ofNullable(builder.sshConnection);
+        if (builder.data == null) {
+            this.data = Optional.empty();
         } else {
-            this.data = data.trim();
+            this.data = Optional.of(builder.data);
         }
-        this.timeout = timeout;
+        if (builder.timeout == 0) {
+            this.timeout = OptionalLong.empty();
+        } else {
+            this.timeout = OptionalLong.of(builder.timeout);
+        }
+        this.toggle = builder.toggle;
     }
 
-    public boolean isZosConnectionSame(final ZosConnection zosConnection) {
-        LOG.debug("*** isZosConnectionSame ***");
-        return this.zosConnection.equals(zosConnection);
+    @Override
+    public boolean equals(Object o) {
+        LOG.debug("*** equals ***");
+        if (o == null || getClass() != o.getClass()) return false;
+        Dependency that = (Dependency) o;
+        return toggle == that.toggle && Objects.equals(zosConnection, that.zosConnection) &&
+                Objects.equals(sshConnection, that.sshConnection) && Objects.equals(data, that.data) &&
+                Objects.equals(timeout, that.timeout);
     }
 
-    public boolean isSshConnectionSame(final SshConnection sshConnection) {
-        LOG.debug("*** isSshConnectionSame ***");
-        return this.sshConnection.equals(sshConnection);
+    @Override
+    public int hashCode() {
+        LOG.debug("*** hashCode ***");
+        return Objects.hash(zosConnection, sshConnection, data, toggle, timeout);
     }
 
-    public boolean isToggleSame(final boolean toggle) {
-        LOG.debug("*** isToggleSame ***");
-        return this.toggle == toggle;
-    }
+    public static class Builder {
 
-    private boolean isDataSame(final String data) {
-        LOG.debug("*** isDataSame ***");
-        return this.data.equals(data);
-    }
-    
-    public boolean isTimeoutSame(final long timeout) {
-        LOG.debug("*** isTimeoutSame ***");
-        return this.timeout == timeout;
-    }
+        private ZosConnection zosConnection;
+        private SshConnection sshConnection;
+        private String data;
+        private boolean toggle;
+        private long timeout;
 
-    public boolean isValid(ZosConnection connection, boolean toggle, long timeout) {
-        return !isZosConnectionSame(connection) || !isTimeoutSame(timeout) || isToggleSame(toggle);
-    }
+        public Builder zosConnection(final ZosConnection zosConnection) {
+            this.zosConnection = zosConnection;
+            return this;
+        }
 
-    public boolean isValid(ZosConnection connection, String data, long timeout) {
-        return !isZosConnectionSame(connection) || !isTimeoutSame(timeout) || isDataSame(data);
-    }
+        public Builder sshConnection(final SshConnection sshConnection) {
+            this.sshConnection = sshConnection;
+            return this;
+        }
 
-    public boolean isValid(ZosConnection connection, long timeout) {
-        return isZosConnectionSame(connection) && isTimeoutSame(timeout);
+        public Builder data(final String data) {
+            this.data = data;
+            return this;
+        }
+
+        public Builder toggle(final boolean toggle) {
+            this.toggle = toggle;
+            return this;
+        }
+
+        public Builder timeout(final long timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        public Dependency build() {
+            return new Dependency(this);
+        }
+
     }
 
 }


### PR DESCRIPTION
Internal enhancements made to the code for dependency usage. 

Changes included:

    Removed multiple constructors to a single builder pattern. 
    Renamed to dependency. 
    Implemented equals method for dependency. 
    Removed all comparison methods which now relies on one equals method. 