### PR TITLE
abstract dependency class

### DIFF
--- a/src/main/java/zos/shell/command/CommandRouter.java
+++ b/src/main/java/zos/shell/command/CommandRouter.java
@@ -96,7 +96,7 @@ public class CommandRouter {
                 if (isParamsExceeded(2, params)) {
                     return;
                 }
-                var changeDirController = controllerContainer.getChangeDirController(currConnection);
+                var changeDirController = controllerContainer.getChangeDirController();
                 responseStatus = changeDirController.cd(currDataset, params[1].toUpperCase());
                 if (responseStatus.isStatus()) {
                     currDataset = responseStatus.getOptionalData();

--- a/src/main/java/zos/shell/controller/BrowseJobController.java
+++ b/src/main/java/zos/shell/controller/BrowseJobController.java
@@ -3,10 +3,12 @@ package zos.shell.controller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zos.shell.constants.Constants;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.job.browse.BrowseLogService;
 
-public class BrowseJobController {
+public class BrowseJobController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(BrowseJobController.class);
 
@@ -14,7 +16,9 @@ public class BrowseJobController {
     private final EnvVariableController envVariableController;
 
     public BrowseJobController(final BrowseLogService browseLogService,
-                               final EnvVariableController envVariableController) {
+                               final EnvVariableController envVariableController,
+                               final Dependency dependency) {
+        super(dependency);
         LOG.debug("*** BrowseJobController ***");
         this.browseLogService = browseLogService;
         this.envVariableController = envVariableController;

--- a/src/main/java/zos/shell/controller/CancelController.java
+++ b/src/main/java/zos/shell/controller/CancelController.java
@@ -2,11 +2,13 @@ package zos.shell.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.job.terminate.TerminateService;
 import zos.shell.singleton.configuration.ConfigSingleton;
 
-public class CancelController {
+public class CancelController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(CancelController.class);
 
@@ -15,7 +17,8 @@ public class CancelController {
     private final EnvVariableController envVariableController;
 
     public CancelController(final TerminateService terminateService, final ConfigSingleton configSingleton,
-                            final EnvVariableController envVariableController) {
+                            final EnvVariableController envVariableController, final Dependency dependency) {
+        super(dependency);
         LOG.debug("*** CancelController ***");
         this.terminateService = terminateService;
         this.configSingleton = configSingleton;

--- a/src/main/java/zos/shell/controller/ConcatController.java
+++ b/src/main/java/zos/shell/controller/ConcatController.java
@@ -2,16 +2,19 @@ package zos.shell.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.dsn.concat.ConcatService;
 
-public class ConcatController {
+public class ConcatController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(ConcatController.class);
 
     private final ConcatService concatService;
 
-    public ConcatController(final ConcatService concatService) {
+    public ConcatController(final ConcatService concatService, final Dependency dependency) {
+        super(dependency);
         LOG.debug("*** ConCatController ***");
         this.concatService = concatService;
     }

--- a/src/main/java/zos/shell/controller/ConsoleController.java
+++ b/src/main/java/zos/shell/controller/ConsoleController.java
@@ -2,11 +2,13 @@ package zos.shell.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.console.ConsoleService;
 import zos.shell.singleton.configuration.ConfigSingleton;
 
-public class ConsoleController {
+public class ConsoleController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(ConsoleController.class);
 
@@ -15,7 +17,8 @@ public class ConsoleController {
     private final EnvVariableController envVariableController;
 
     public ConsoleController(final ConsoleService consoleService, final ConfigSingleton configSingleton,
-                             final EnvVariableController envVariableController) {
+                             final EnvVariableController envVariableController, final Dependency dependency) {
+        super(dependency);
         LOG.debug("*** ConsoleController ***");
         this.consoleService = consoleService;
         this.configSingleton = configSingleton;

--- a/src/main/java/zos/shell/controller/CopyController.java
+++ b/src/main/java/zos/shell/controller/CopyController.java
@@ -2,16 +2,19 @@ package zos.shell.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.dsn.copy.CopyService;
 
-public class CopyController {
+public class CopyController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(CopyController.class);
 
     private final CopyService copyService;
 
-    public CopyController(final CopyService copyService) {
+    public CopyController(final CopyService copyService, final Dependency dependency) {
+        super(dependency);
         LOG.debug("*** CopyController ***");
         this.copyService = copyService;
     }

--- a/src/main/java/zos/shell/controller/CountController.java
+++ b/src/main/java/zos/shell/controller/CountController.java
@@ -2,16 +2,19 @@ package zos.shell.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.dsn.count.CountService;
 
-public class CountController {
+public class CountController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(CountController.class);
 
     private final CountService countService;
 
-    public CountController(final CountService countService) {
+    public CountController(final CountService countService, final Dependency dependency) {
+        super(dependency);
         LOG.debug("*** CountController ***");
         this.countService = countService;
     }

--- a/src/main/java/zos/shell/controller/DeleteController.java
+++ b/src/main/java/zos/shell/controller/DeleteController.java
@@ -2,16 +2,19 @@ package zos.shell.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.dsn.delete.DeleteService;
 
-public class DeleteController {
+public class DeleteController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(DeleteController.class);
 
     private final DeleteService deleteService;
 
-    public DeleteController(final DeleteService deleteService) {
+    public DeleteController(final DeleteService deleteService, final Dependency dependency) {
+        super(dependency);
         LOG.debug("*** DeleteController ***");
         this.deleteService = deleteService;
     }

--- a/src/main/java/zos/shell/controller/DownloadDsnController.java
+++ b/src/main/java/zos/shell/controller/DownloadDsnController.java
@@ -3,6 +3,8 @@ package zos.shell.controller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zos.shell.constants.Constants;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.record.DatasetMember;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.dsn.download.*;
@@ -16,7 +18,7 @@ import java.util.List;
 import java.util.OptionalInt;
 import java.util.stream.IntStream;
 
-public class DownloadDsnController {
+public class DownloadDsnController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(DownloadDsnController.class);
 
@@ -30,8 +32,9 @@ public class DownloadDsnController {
                                  final DownloadPdsMemberService downloadPdsMemberService,
                                  final DownloadSeqDatasetService downloadSeqDatasetService,
                                  final DownloadAllMembersService downloadAllMembersService,
-                                 final DownloadMembersService downloadMembersService) {
-
+                                 final DownloadMembersService downloadMembersService,
+                                 final Dependency dependency) {
+        super(dependency);
         LOG.debug("*** DownloadDsnController ***");
         this.downloadMemberService = downloadMemberService;
         this.downloadPdsMemberService = downloadPdsMemberService;

--- a/src/main/java/zos/shell/controller/DownloadJobController.java
+++ b/src/main/java/zos/shell/controller/DownloadJobController.java
@@ -2,16 +2,19 @@ package zos.shell.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.job.download.DownloadJobService;
 
-public class DownloadJobController {
+public class DownloadJobController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(DownloadJobController.class);
 
     private final DownloadJobService downloadJobService;
 
-    public DownloadJobController(final DownloadJobService downloadJobService) {
+    public DownloadJobController(final DownloadJobService downloadJobService, final Dependency dependency) {
+        super(dependency);
         LOG.debug("*** DownloadJobController ***");
         this.downloadJobService = downloadJobService;
     }

--- a/src/main/java/zos/shell/controller/EditController.java
+++ b/src/main/java/zos/shell/controller/EditController.java
@@ -2,16 +2,19 @@ package zos.shell.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.dsn.edit.EditService;
 
-public class EditController {
+public class EditController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(EditController.class);
 
     private final EditService editService;
 
-    public EditController(final EditService editService) {
+    public EditController(final EditService editService, final Dependency dependency) {
+        super(dependency);
         LOG.debug("*** EditController ***");
         this.editService = editService;
     }

--- a/src/main/java/zos/shell/controller/GrepController.java
+++ b/src/main/java/zos/shell/controller/GrepController.java
@@ -2,15 +2,18 @@ package zos.shell.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.service.grep.GrepService;
 
-public class GrepController {
+public class GrepController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrepController.class);
 
     private final GrepService grepService;
 
-    public GrepController(final GrepService grepService) {
+    public GrepController(final GrepService grepService, final Dependency dependency) {
+        super(dependency);
         LOG.debug("*** GrepController ***");
         this.grepService = grepService;
     }

--- a/src/main/java/zos/shell/controller/ListingController.java
+++ b/src/main/java/zos/shell/controller/ListingController.java
@@ -2,18 +2,21 @@ package zos.shell.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.dsn.list.ListingService;
 import zos.shell.utility.ResponseUtil;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
 
-public class ListingController {
+public class ListingController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(ListingController.class);
 
     private final ListingService listingService;
 
-    public ListingController(final ListingService listingService) {
+    public ListingController(final ListingService listingService, final Dependency dependency) {
+        super(dependency);
         LOG.debug("*** ListingController ***");
         this.listingService = listingService;
     }

--- a/src/main/java/zos/shell/controller/MakeDirController.java
+++ b/src/main/java/zos/shell/controller/MakeDirController.java
@@ -5,20 +5,23 @@ import org.beryx.textio.TextTerminal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zos.shell.constants.Constants;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.dsn.makedir.MakeDirService;
 import zos.shell.utility.DsnUtil;
 import zos.shell.utility.StrUtil;
 import zowe.client.sdk.zosfiles.dsn.input.CreateParams;
 
-public class MakeDirController {
+public class MakeDirController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(MakeDirController.class);
 
     private final MakeDirService makeDirService;
     private final TextTerminal<?> terminal;
 
-    public MakeDirController(final TextTerminal<?> terminal, final MakeDirService makeDirService) {
+    public MakeDirController(final TextTerminal<?> terminal, final MakeDirService makeDirService, final Dependency dependency) {
+        super(dependency);
         LOG.debug("*** MakeDirController ***");
         this.terminal = terminal;
         this.makeDirService = makeDirService;

--- a/src/main/java/zos/shell/controller/ProcessLstController.java
+++ b/src/main/java/zos/shell/controller/ProcessLstController.java
@@ -2,16 +2,19 @@ package zos.shell.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.job.processlst.ProcessLstService;
 
-public class ProcessLstController {
+public class ProcessLstController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(ProcessLstController.class);
 
     private final ProcessLstService processListingService;
 
-    public ProcessLstController(final ProcessLstService processListingService) {
+    public ProcessLstController(final ProcessLstService processListingService, final Dependency dependency) {
+        super(dependency);
         this.processListingService = processListingService;
     }
 

--- a/src/main/java/zos/shell/controller/PurgeController.java
+++ b/src/main/java/zos/shell/controller/PurgeController.java
@@ -2,16 +2,19 @@ package zos.shell.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.job.purge.PurgeService;
 
-public class PurgeController {
+public class PurgeController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(PurgeController.class);
 
     private final PurgeService purgeService;
 
-    public PurgeController(final PurgeService purgeService) {
+    public PurgeController(final PurgeService purgeService, final Dependency dependency) {
+        super(dependency);
         this.purgeService = purgeService;
     }
 

--- a/src/main/java/zos/shell/controller/RenameController.java
+++ b/src/main/java/zos/shell/controller/RenameController.java
@@ -2,16 +2,19 @@ package zos.shell.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.rename.RenameService;
 
-public class RenameController {
+public class RenameController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(RenameController.class);
 
     private final RenameService renameService;
 
-    public RenameController(final RenameService renameService) {
+    public RenameController(final RenameService renameService, final Dependency dependency) {
+        super(dependency);
         LOG.debug("*** RenameController ***");
         this.renameService = renameService;
     }

--- a/src/main/java/zos/shell/controller/SaveController.java
+++ b/src/main/java/zos/shell/controller/SaveController.java
@@ -2,16 +2,19 @@ package zos.shell.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.dsn.save.SaveService;
 
-public class SaveController {
+public class SaveController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(SaveController.class);
 
     private final SaveService saveService;
 
-    public SaveController(final SaveService saveService) {
+    public SaveController(final SaveService saveService, final Dependency dependency) {
+        super(dependency);
         LOG.debug("*** SaveController ***");
         this.saveService = saveService;
     }

--- a/src/main/java/zos/shell/controller/StopController.java
+++ b/src/main/java/zos/shell/controller/StopController.java
@@ -2,11 +2,13 @@ package zos.shell.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.job.terminate.TerminateService;
 import zos.shell.singleton.configuration.ConfigSingleton;
 
-public class StopController {
+public class StopController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(StopController.class);
 
@@ -15,7 +17,8 @@ public class StopController {
     private final EnvVariableController envVariableController;
 
     public StopController(final TerminateService terminateService, final ConfigSingleton configSingleton,
-                          final EnvVariableController envVariableController) {
+                          final EnvVariableController envVariableController, final Dependency dependency) {
+        super(dependency);
         LOG.debug("*** TerminateController ***");
         this.terminateService = terminateService;
         this.configSingleton = configSingleton;

--- a/src/main/java/zos/shell/controller/SubmitController.java
+++ b/src/main/java/zos/shell/controller/SubmitController.java
@@ -2,16 +2,19 @@ package zos.shell.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.job.submit.SubmitService;
 
-public class SubmitController {
+public class SubmitController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(SubmitController.class);
 
     private final SubmitService submitService;
 
-    public SubmitController(final SubmitService submitService) {
+    public SubmitController(final SubmitService submitService, final Dependency dependency) {
+        super(dependency);
         LOG.debug("*** SubmitController ***");
         this.submitService = submitService;
     }

--- a/src/main/java/zos/shell/controller/TailController.java
+++ b/src/main/java/zos/shell/controller/TailController.java
@@ -2,19 +2,22 @@ package zos.shell.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.job.tail.TailService;
 import zos.shell.service.search.SearchCache;
 
 import java.util.Arrays;
 
-public class TailController {
+public class TailController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(TailController.class);
 
     private final TailService tailService;
 
-    public TailController(final TailService tailService) {
+    public TailController(final TailService tailService, final Dependency dependency) {
+        super(dependency);
         LOG.debug("*** TailController ***");
         this.tailService = tailService;
     }

--- a/src/main/java/zos/shell/controller/TouchController.java
+++ b/src/main/java/zos/shell/controller/TouchController.java
@@ -2,16 +2,19 @@ package zos.shell.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.dsn.touch.TouchService;
 
-public class TouchController {
+public class TouchController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(TouchController.class);
 
     private final TouchService touchService;
 
-    public TouchController(final TouchService touchService) {
+    public TouchController(final TouchService touchService, final Dependency dependency) {
+        super(dependency);
         LOG.debug("*** TouchController ***");
         this.touchService = touchService;
     }

--- a/src/main/java/zos/shell/controller/TsoController.java
+++ b/src/main/java/zos/shell/controller/TsoController.java
@@ -2,11 +2,13 @@ package zos.shell.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.tso.TsoService;
 import zos.shell.singleton.configuration.ConfigSingleton;
 
-public class TsoController {
+public class TsoController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(TsoController.class);
 
@@ -15,7 +17,8 @@ public class TsoController {
     private final EnvVariableController envVariableController;
 
     public TsoController(final TsoService tsoService, final ConfigSingleton configSingleton,
-                         final EnvVariableController envVariableController) {
+                         final EnvVariableController envVariableController, final Dependency dependency) {
+        super(dependency);
         LOG.debug("*** TsoController ***");
         this.tsoService = tsoService;
         this.configSingleton = configSingleton;

--- a/src/main/java/zos/shell/controller/UnameController.java
+++ b/src/main/java/zos/shell/controller/UnameController.java
@@ -2,11 +2,13 @@ package zos.shell.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.service.uname.UnameService;
 import zos.shell.singleton.configuration.ConfigSingleton;
 import zowe.client.sdk.core.ZosConnection;
 
-public class UnameController {
+public class UnameController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(UnameController.class);
 
@@ -15,7 +17,8 @@ public class UnameController {
     private final EnvVariableController envVariableController;
 
     public UnameController(final UnameService unameService, final ConfigSingleton configSingleton,
-                           final EnvVariableController envVariableController) {
+                           final EnvVariableController envVariableController, final Dependency dependency) {
+        super(dependency);
         LOG.debug("*** UnameController ***");
         this.unameService = unameService;
         this.configSingleton = configSingleton;

--- a/src/main/java/zos/shell/controller/UssController.java
+++ b/src/main/java/zos/shell/controller/UssController.java
@@ -2,15 +2,18 @@ package zos.shell.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import zos.shell.controller.dependency.Dependency;
+import zos.shell.controller.dependency.DependencyController;
 import zos.shell.service.omvs.SshService;
 
-public class UssController {
+public class UssController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(UssController.class);
 
     private final SshService sshService;
 
-    public UssController(final SshService sshService) {
+    public UssController(final SshService sshService, final Dependency dependency) {
+        super(dependency);
         LOG.debug("*** UssController ***");
         this.sshService = sshService;
     }

--- a/src/main/java/zos/shell/controller/dependency/Dependency.java
+++ b/src/main/java/zos/shell/controller/dependency/Dependency.java
@@ -1,4 +1,4 @@
-package zos.shell.controller.container;
+package zos.shell.controller.dependency;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/zos/shell/controller/dependency/DependencyController.java
+++ b/src/main/java/zos/shell/controller/dependency/DependencyController.java
@@ -1,0 +1,25 @@
+package zos.shell.controller.dependency;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class DependencyController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DependencyController.class);
+
+    private final Dependency dependency;
+
+    protected DependencyController(Dependency dependency) {
+        LOG.debug("*** DependencyController ***");
+        this.dependency = dependency;
+    }
+
+    public boolean isNotValid(Dependency dependency) {
+        LOG.debug("*** isNotValid ***");
+        if (this.dependency == null) {
+            return true;
+        }
+        return !this.dependency.equals(dependency);
+    }
+
+}


### PR DESCRIPTION
Implemented an abstract dependency class. Each controller that requires a dependency check will now extend its class to the new abstract class. This cuts down on more of the clutter in the ControllerFactoryContainer class; as such, it no longer requires to handle a map of dependencies. A dependency is saved within each controller now. 