### PR TITLE
Consistent environment variable(s) usage. 

### DIFF
--- a/src/main/java/zos/shell/controller/BrowseJobController.java
+++ b/src/main/java/zos/shell/controller/BrowseJobController.java
@@ -27,7 +27,7 @@ public class BrowseJobController extends DependencyController {
     public String browseJob(final String target) {
         LOG.debug("*** browseJob ***");
         ResponseStatus responseStatus = browseLogService.browseJob(target);
-        String browseLimit = envVariableController.getValueByEnv("BROWSE_LIMIT").trim();
+        String browseLimit = envVariableController.getValueByEnv("BROWSE_LIMIT");
         int browseLimitInt = 0;
         if (!browseLimit.isBlank()) {
             try {

--- a/src/main/java/zos/shell/controller/CancelController.java
+++ b/src/main/java/zos/shell/controller/CancelController.java
@@ -6,31 +6,26 @@ import zos.shell.controller.dependency.Dependency;
 import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.job.terminate.TerminateService;
-import zos.shell.singleton.configuration.ConfigSingleton;
 
 public class CancelController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(CancelController.class);
 
     private final TerminateService terminateService;
-    private final ConfigSingleton configSingleton;
     private final EnvVariableController envVariableController;
 
-    public CancelController(final TerminateService terminateService, final ConfigSingleton configSingleton,
-                            final EnvVariableController envVariableController, final Dependency dependency) {
+    public CancelController(final TerminateService terminateService,
+                            final EnvVariableController envVariableController,
+                            final Dependency dependency) {
         super(dependency);
         LOG.debug("*** CancelController ***");
         this.terminateService = terminateService;
-        this.configSingleton = configSingleton;
         this.envVariableController = envVariableController;
     }
 
     public String cancel(final String target) {
         LOG.debug("*** cancel ***");
-        String consoleName = envVariableController.getValueByEnv("CONSOLE_NAME").trim();
-        if (consoleName.isBlank()) {
-            consoleName = configSingleton.getConfigSettings().getConsoleName();
-        }
+        String consoleName = envVariableController.getValueByEnv("CONSOLE_NAME");
         ResponseStatus responseStatus = terminateService.terminate(TerminateService.Type.CANCEL, consoleName, target);
         return responseStatus.getMessage();
     }

--- a/src/main/java/zos/shell/controller/ConsoleController.java
+++ b/src/main/java/zos/shell/controller/ConsoleController.java
@@ -6,31 +6,25 @@ import zos.shell.controller.dependency.Dependency;
 import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.console.ConsoleService;
-import zos.shell.singleton.configuration.ConfigSingleton;
 
 public class ConsoleController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(ConsoleController.class);
 
     private final ConsoleService consoleService;
-    private final ConfigSingleton configSingleton;
     private final EnvVariableController envVariableController;
 
-    public ConsoleController(final ConsoleService consoleService, final ConfigSingleton configSingleton,
-                             final EnvVariableController envVariableController, final Dependency dependency) {
+    public ConsoleController(final ConsoleService consoleService, final EnvVariableController envVariableController,
+                             final Dependency dependency) {
         super(dependency);
         LOG.debug("*** ConsoleController ***");
         this.consoleService = consoleService;
-        this.configSingleton = configSingleton;
         this.envVariableController = envVariableController;
     }
 
     public String issueConsole(final String command) {
         LOG.debug("*** issueConsole ***");
-        String consoleName = envVariableController.getValueByEnv("CONSOLE_NAME").trim();
-        if (consoleName.isBlank()) {
-            consoleName = configSingleton.getConfigSettings().getConsoleName();
-        }
+        String consoleName = envVariableController.getValueByEnv("CONSOLE_NAME");
         ResponseStatus responseStatus = consoleService.issueConsole(consoleName, command);
         return responseStatus.getMessage();
     }

--- a/src/main/java/zos/shell/controller/DownloadDsnController.java
+++ b/src/main/java/zos/shell/controller/DownloadDsnController.java
@@ -8,7 +8,6 @@ import zos.shell.controller.dependency.DependencyController;
 import zos.shell.record.DatasetMember;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.dsn.download.*;
-import zos.shell.singleton.configuration.ConfigSingleton;
 import zos.shell.utility.DsnUtil;
 import zos.shell.utility.ResponseUtil;
 
@@ -27,12 +26,14 @@ public class DownloadDsnController extends DependencyController {
     private final DownloadSeqDatasetService downloadSeqDatasetService;
     private final DownloadAllMembersService downloadAllMembersService;
     private final DownloadMembersService downloadMembersService;
+    private final EnvVariableController envVariableController;
 
     public DownloadDsnController(final DownloadMemberService downloadMemberService,
                                  final DownloadPdsMemberService downloadPdsMemberService,
                                  final DownloadSeqDatasetService downloadSeqDatasetService,
                                  final DownloadAllMembersService downloadAllMembersService,
                                  final DownloadMembersService downloadMembersService,
+                                 final EnvVariableController envVariableController,
                                  final Dependency dependency) {
         super(dependency);
         LOG.debug("*** DownloadDsnController ***");
@@ -41,21 +42,21 @@ public class DownloadDsnController extends DependencyController {
         this.downloadSeqDatasetService = downloadSeqDatasetService;
         this.downloadAllMembersService = downloadAllMembersService;
         this.downloadMembersService = downloadMembersService;
+        this.envVariableController = envVariableController;
     }
 
     public List<String> download(final String dataset, final String target) {
         LOG.debug("*** download ***");
         List<String> results = new ArrayList<>();
 
-        // TODO incorporate env variable downloadPath availability too..
-        var configSettings = ConfigSingleton.getInstance().getConfigSettings();
-        if (configSettings.getDownloadPath().isBlank()) {
+        String downloadPath = envVariableController.getValueByEnv("DOWNLOAD_PATH");
+        if (downloadPath.isBlank()) {
             results.add("downloadPath configuration missing, try again...");
             return results;
         }
-        File dir = new File(configSettings.getDownloadPath());
+        File dir = new File(downloadPath);
         if (!dir.isDirectory()) {
-            results.add("downloadPath " + configSettings.getDownloadPath() + " not found, try again...");
+            results.add("downloadPath " + downloadPath + " not found, try again...");
             return results;
         }
 
@@ -116,6 +117,4 @@ public class DownloadDsnController extends DependencyController {
         return results;
     }
 
-
 }
-

--- a/src/main/java/zos/shell/controller/EnvVariableController.java
+++ b/src/main/java/zos/shell/controller/EnvVariableController.java
@@ -36,7 +36,7 @@ public class EnvVariableController {
         if (values.length != 2) {
             return Constants.INVALID_COMMAND;
         }
-        envVariableService.setEnvVariable(values[0].trim(), values[1].trim());
+        envVariableService.setEnvVariable(values[0], values[1]);
         if (values[0].equalsIgnoreCase("acctnum")) {
             if (!StrUtil.isStrNum(values[1])) {
                 return "ACCTNUM value not a number, try again...";

--- a/src/main/java/zos/shell/controller/StopController.java
+++ b/src/main/java/zos/shell/controller/StopController.java
@@ -6,31 +6,26 @@ import zos.shell.controller.dependency.Dependency;
 import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.job.terminate.TerminateService;
-import zos.shell.singleton.configuration.ConfigSingleton;
 
 public class StopController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(StopController.class);
 
     private final TerminateService terminateService;
-    private final ConfigSingleton configSingleton;
     private final EnvVariableController envVariableController;
 
-    public StopController(final TerminateService terminateService, final ConfigSingleton configSingleton,
-                          final EnvVariableController envVariableController, final Dependency dependency) {
+    public StopController(final TerminateService terminateService,
+                          final EnvVariableController envVariableController,
+                          final Dependency dependency) {
         super(dependency);
         LOG.debug("*** TerminateController ***");
         this.terminateService = terminateService;
-        this.configSingleton = configSingleton;
         this.envVariableController = envVariableController;
     }
 
     public String stop(final String target) {
         LOG.debug("*** stop ***");
-        String consoleName = envVariableController.getValueByEnv("CONSOLE_NAME").trim();
-        if (consoleName.isBlank()) {
-            consoleName = configSingleton.getConfigSettings().getConsoleName();
-        }
+        String consoleName = envVariableController.getValueByEnv("CONSOLE_NAME");
         ResponseStatus responseStatus = terminateService.terminate(TerminateService.Type.STOP, consoleName, target);
         return responseStatus.getMessage();
     }

--- a/src/main/java/zos/shell/controller/TsoController.java
+++ b/src/main/java/zos/shell/controller/TsoController.java
@@ -6,31 +6,25 @@ import zos.shell.controller.dependency.Dependency;
 import zos.shell.controller.dependency.DependencyController;
 import zos.shell.response.ResponseStatus;
 import zos.shell.service.tso.TsoService;
-import zos.shell.singleton.configuration.ConfigSingleton;
 
 public class TsoController extends DependencyController {
 
     private static final Logger LOG = LoggerFactory.getLogger(TsoController.class);
 
     private final TsoService tsoService;
-    private final ConfigSingleton configSingleton;
     private final EnvVariableController envVariableController;
 
-    public TsoController(final TsoService tsoService, final ConfigSingleton configSingleton,
-                         final EnvVariableController envVariableController, final Dependency dependency) {
+    public TsoController(final TsoService tsoService, final EnvVariableController envVariableController,
+                         final Dependency dependency) {
         super(dependency);
         LOG.debug("*** TsoController ***");
         this.tsoService = tsoService;
-        this.configSingleton = configSingleton;
         this.envVariableController = envVariableController;
     }
 
     public String issueCommand(final String command) {
         LOG.debug("*** issueCommand ***");
-        String accountNumber = envVariableController.getValueByEnv("ACCOUNT_NUMBER").trim();
-        if (accountNumber.isBlank()) {
-            accountNumber = configSingleton.getConfigSettings().getAccountNumber();
-        }
+        String accountNumber = envVariableController.getValueByEnv("ACCOUNT_NUMBER");
         ResponseStatus responseStatus = tsoService.issueCommand(accountNumber, command);
         return responseStatus.getMessage();
     }

--- a/src/main/java/zos/shell/controller/UnameController.java
+++ b/src/main/java/zos/shell/controller/UnameController.java
@@ -5,7 +5,6 @@ import org.slf4j.LoggerFactory;
 import zos.shell.controller.dependency.Dependency;
 import zos.shell.controller.dependency.DependencyController;
 import zos.shell.service.uname.UnameService;
-import zos.shell.singleton.configuration.ConfigSingleton;
 import zowe.client.sdk.core.ZosConnection;
 
 public class UnameController extends DependencyController {
@@ -13,24 +12,20 @@ public class UnameController extends DependencyController {
     private static final Logger LOG = LoggerFactory.getLogger(UnameController.class);
 
     private final UnameService unameService;
-    private final ConfigSingleton configSingleton;
     private final EnvVariableController envVariableController;
 
-    public UnameController(final UnameService unameService, final ConfigSingleton configSingleton,
-                           final EnvVariableController envVariableController, final Dependency dependency) {
+    public UnameController(final UnameService unameService,
+                           final EnvVariableController envVariableController,
+                           final Dependency dependency) {
         super(dependency);
         LOG.debug("*** UnameController ***");
         this.unameService = unameService;
-        this.configSingleton = configSingleton;
         this.envVariableController = envVariableController;
     }
 
     public String uname(final ZosConnection connection) {
         LOG.debug("*** uname ***");
-        String consoleName = envVariableController.getValueByEnv("CONSOLE_NAME").trim();
-        if (consoleName.isBlank()) {
-            consoleName = configSingleton.getConfigSettings().getConsoleName();
-        }
+        String consoleName = envVariableController.getValueByEnv("CONSOLE_NAME");
         return unameService.getUname(connection.getHost(), consoleName);
     }
 

--- a/src/main/java/zos/shell/controller/container/ControllerFactoryContainer.java
+++ b/src/main/java/zos/shell/controller/container/ControllerFactoryContainer.java
@@ -39,7 +39,6 @@ import zos.shell.service.tso.TsoService;
 import zos.shell.service.uname.UnameService;
 import zos.shell.service.usermod.UsermodService;
 import zos.shell.singleton.ConnSingleton;
-import zos.shell.singleton.configuration.ConfigSingleton;
 import zowe.client.sdk.core.SshConnection;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.zosconsole.method.IssueConsole;
@@ -59,8 +58,7 @@ public class ControllerFactoryContainer {
 
     private static final Logger LOG = LoggerFactory.getLogger(ControllerFactoryContainer.class);
     private final EnvVariableController envVariableController = new EnvVariableController(new EnvVariableService());
-    private final PathService pathService =
-            new PathService(ConfigSingleton.getInstance(), ConnSingleton.getInstance(), this.envVariableController);
+    private final PathService pathService = new PathService(ConnSingleton.getInstance(), this.envVariableController);
     private final Map<ContainerType.Name, Object> controllers = new HashMap<>();
 
     public ControllerFactoryContainer() {
@@ -88,8 +86,7 @@ public class ControllerFactoryContainer {
         if (controller == null || controller.isNotValid(dependency)) {
             var issueConsole = new IssueConsole(connection);
             var service = new TerminateService(issueConsole, timeout);
-            controller = new CancelController(
-                    service, ConfigSingleton.getInstance(), this.envVariableController, dependency);
+            controller = new CancelController(service, this.envVariableController, dependency);
             this.controllers.put(ContainerType.Name.CANCEL, controller);
         }
         return controller;
@@ -148,7 +145,7 @@ public class ControllerFactoryContainer {
         var dependency = new Dependency.Builder().zosConnection(connection).timeout(timeout).build();
         if (controller == null || controller.isNotValid(dependency)) {
             var service = new ConsoleService(connection, timeout);
-            controller = new ConsoleController(service, ConfigSingleton.getInstance(), this.envVariableController, dependency);
+            controller = new ConsoleController(service, this.envVariableController, dependency);
             this.controllers.put(ContainerType.Name.CONSOLE, controller);
         }
         return controller;
@@ -205,7 +202,8 @@ public class ControllerFactoryContainer {
             var downloadMembersService = new DownloadMembersService(connection,
                     new DownloadMemberListService(connection, isBinary, timeout), timeout);
             controller = new DownloadDsnController(downloadMemberService, downloadPdsMemberService,
-                    downloadSeqDatasetService, downloadAllMembersService, downloadMembersService, dependency);
+                    downloadSeqDatasetService, downloadAllMembersService, downloadMembersService,
+                    this.envVariableController, dependency);
             this.controllers.put(ContainerType.Name.DELETE, controller);
         }
         return controller;
@@ -286,7 +284,7 @@ public class ControllerFactoryContainer {
         LOG.debug("*** getLocalFilesController ***");
         var controller = (LocalFilesController) controllers.get(ContainerType.Name.LOCAL_FILE);
         if (controller == null) {
-            var service = new LocalFileService();
+            var service = new LocalFileService(this.envVariableController);
             controller = new LocalFilesController(service);
             this.controllers.put(ContainerType.Name.LOCAL_FILE, controller);
         }
@@ -376,7 +374,7 @@ public class ControllerFactoryContainer {
         if (controller == null || controller.isNotValid(dependency)) {
             var issueConsole = new IssueConsole(connection);
             var service = new TerminateService(issueConsole, timeout);
-            controller = new StopController(service, ConfigSingleton.getInstance(), this.envVariableController, dependency);
+            controller = new StopController(service, this.envVariableController, dependency);
             this.controllers.put(ContainerType.Name.STOP, controller);
         }
         return controller;
@@ -430,7 +428,7 @@ public class ControllerFactoryContainer {
         if (controller == null || controller.isNotValid(dependency)) {
             var issueTso = new IssueTso(connection);
             var service = new TsoService(issueTso, timeout);
-            controller = new TsoController(service, ConfigSingleton.getInstance(), this.envVariableController, dependency);
+            controller = new TsoController(service, this.envVariableController, dependency);
             this.controllers.put(ContainerType.Name.TSO, controller);
         }
         return controller;
@@ -443,7 +441,7 @@ public class ControllerFactoryContainer {
         if (controller == null || controller.isNotValid(dependency)) {
             var issueConsole = new IssueConsole(connection);
             var service = new UnameService(issueConsole, timeout);
-            controller = new UnameController(service, ConfigSingleton.getInstance(), this.envVariableController, dependency);
+            controller = new UnameController(service, this.envVariableController, dependency);
             this.controllers.put(ContainerType.Name.UNAME, controller);
         }
         return controller;

--- a/src/main/java/zos/shell/service/dsn/download/DownloadMemberListService.java
+++ b/src/main/java/zos/shell/service/dsn/download/DownloadMemberListService.java
@@ -8,7 +8,6 @@ import zos.shell.response.ResponseStatus;
 import zos.shell.service.env.EnvVariableService;
 import zos.shell.service.path.PathService;
 import zos.shell.singleton.ConnSingleton;
-import zos.shell.singleton.configuration.ConfigSingleton;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.zosfiles.dsn.methods.DsnGet;
 import zowe.client.sdk.zosfiles.dsn.response.Member;
@@ -44,7 +43,7 @@ public class DownloadMemberListService {
                 if (member.getMember().isPresent()) {
                     String name = member.getMember().get();
                     futures.add(pool.submit(new FutureMemberDownload(new DsnGet(connection),
-                            new PathService(ConfigSingleton.getInstance(), ConnSingleton.getInstance(),
+                            new PathService(ConnSingleton.getInstance(),
                                     new EnvVariableController(new EnvVariableService())), dataset, name, isBinary)));
                 }
             }

--- a/src/main/java/zos/shell/service/env/EnvVariableService.java
+++ b/src/main/java/zos/shell/service/env/EnvVariableService.java
@@ -35,7 +35,7 @@ public class EnvVariableService {
         while (m.find()) {
             value = m.group(1);
         }
-        envVariableSingleton.getVariables().put(key.toUpperCase(), value);
+        envVariableSingleton.getVariables().put(key.toUpperCase().trim(), value.trim());
     }
 
 }

--- a/src/main/java/zos/shell/service/grep/GrepService.java
+++ b/src/main/java/zos/shell/service/grep/GrepService.java
@@ -10,7 +10,6 @@ import zos.shell.service.env.EnvVariableService;
 import zos.shell.service.memberlst.MemberListingService;
 import zos.shell.service.path.PathService;
 import zos.shell.singleton.ConnSingleton;
-import zos.shell.singleton.configuration.ConfigSingleton;
 import zos.shell.utility.ResponseUtil;
 import zowe.client.sdk.core.ZosConnection;
 import zowe.client.sdk.rest.exception.ZosmfRequestException;
@@ -107,7 +106,7 @@ public class GrepService {
                                        final ArrayList<Future<List<String>>> futures, final List<Member> members) {
         for (var member : members) {
             var concatService = new ConcatService(new Download(new DsnGet(connection),
-                    new PathService(ConfigSingleton.getInstance(), ConnSingleton.getInstance(),
+                    new PathService(ConnSingleton.getInstance(),
                             new EnvVariableController(new EnvVariableService())), false), timeout);
             if (member.getMember().isPresent()) {
                 var name = member.getMember().get();

--- a/src/main/java/zos/shell/service/localfile/LocalFileService.java
+++ b/src/main/java/zos/shell/service/localfile/LocalFileService.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.SystemUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zos.shell.constants.Constants;
+import zos.shell.controller.EnvVariableController;
 import zos.shell.singleton.configuration.ConfigSingleton;
 
 import java.io.File;
@@ -20,8 +21,11 @@ public class LocalFileService {
     private static final String DIRECTORY_PATH_WINDOWS = Constants.DEFAULT_DOWNLOAD_PATH_WINDOWS + "\\";
     private static final String DIRECTORY_PATH_MAC = Constants.DEFAULT_DOWNLOAD_PATH_MAC + "/";
 
-    public LocalFileService() {
+    private final EnvVariableController envVariableController;
+
+    public LocalFileService(EnvVariableController envVariableController) {
         LOG.debug("*** LocalFileService ***");
+        this.envVariableController = envVariableController;
     }
 
     public StringBuilder listFiles(final String target) {
@@ -33,8 +37,9 @@ public class LocalFileService {
         LOG.debug("*** getFiles ***");
         var result = new StringBuilder();
         String path;
+        String downloadPath = envVariableController.getValueByEnv("DOWNLOAD_PATH");
         var configSettings = ConfigSingleton.getInstance().getConfigSettings();
-        var configPath = configSettings != null ? configSettings.getDownloadPath() : "";
+        var configPath = configSettings != null ? downloadPath : "";
         var targetValue = target != null && !target.isBlank() ? target : "";
         if (SystemUtils.IS_OS_WINDOWS) {
             var configPathValue = configPath + (!configPath.endsWith("\\") ? "\\" : "") + targetValue;

--- a/src/main/java/zos/shell/service/path/PathService.java
+++ b/src/main/java/zos/shell/service/path/PathService.java
@@ -6,7 +6,6 @@ import org.slf4j.LoggerFactory;
 import zos.shell.constants.Constants;
 import zos.shell.controller.EnvVariableController;
 import zos.shell.singleton.ConnSingleton;
-import zos.shell.singleton.configuration.ConfigSingleton;
 import zos.shell.utility.DsnUtil;
 
 public class PathService {
@@ -17,16 +16,13 @@ public class PathService {
 
     private static final String DIRECTORY_PATH_MAC = Constants.DEFAULT_DOWNLOAD_PATH_MAC + "/";
 
-    private final ConfigSingleton configSingleton;
     private final ConnSingleton connSingleton;
     private final EnvVariableController envVariableController;
     private String pathToDirectory;
     private String pathToDirectoryWithFileName;
 
-    public PathService(final ConfigSingleton configSingleton, final ConnSingleton connSingleton,
-                       final EnvVariableController envVariableController) {
+    public PathService(final ConnSingleton connSingleton, final EnvVariableController envVariableController) {
         LOG.debug("*** PathService ***");
-        this.configSingleton = configSingleton;
         this.connSingleton = connSingleton;
         this.envVariableController = envVariableController;
     }
@@ -47,20 +43,17 @@ public class PathService {
 
     private void initialize(final String dataset, final String target) {
         LOG.debug("*** initialize ***");
-        var configPath = envVariableController.getValueByEnv("DOWNLOAD_PATH").trim();
-        if (configPath.isBlank()) {
-            configPath = configSingleton.getConfigSettings().getDownloadPath();
-        }
+        var downloadPath = envVariableController.getValueByEnv("DOWNLOAD_PATH");
 
         if (SystemUtils.IS_OS_WINDOWS) {
-            pathToDirectory = !configPath.isBlank() ? configPath +
-                    (!configPath.endsWith("\\") ? "\\" : "") +
+            pathToDirectory = !downloadPath.isBlank() ? downloadPath +
+                    (!downloadPath.endsWith("\\") ? "\\" : "") +
                     connSingleton.getCurrZosConnection().getHost() + "\\" + dataset :
                     DIRECTORY_PATH_WINDOWS + connSingleton.getCurrZosConnection().getHost() + "\\" + dataset;
             pathToDirectoryWithFileName = pathToDirectory + "\\" + target;
         } else if (SystemUtils.IS_OS_MAC_OSX) {
-            pathToDirectory = configPath.isBlank() ? configPath +
-                    (!configPath.endsWith("/") ? "/" : "") +
+            pathToDirectory = downloadPath.isBlank() ? downloadPath +
+                    (!downloadPath.endsWith("/") ? "/" : "") +
                     connSingleton.getCurrZosConnection().getHost() + "/" + dataset :
                     DIRECTORY_PATH_MAC + connSingleton.getCurrZosConnection().getHost() + "/" + dataset;
             pathToDirectoryWithFileName = pathToDirectory + "/" + target;

--- a/src/main/java/zos/shell/singleton/configuration/record/ConfigSettings.java
+++ b/src/main/java/zos/shell/singleton/configuration/record/ConfigSettings.java
@@ -18,53 +18,29 @@ public class ConfigSettings {
                           final Window window) {
         this.hostName = hostName;
         if (hostName != null && !hostName.isBlank()) {
-            EnvVariableSingleton.getInstance().getVariables().put("HOSTNAME", hostName);
+            EnvVariableSingleton.getInstance().getVariables().put("HOSTNAME", hostName.trim());
         }
         this.downloadPath = downloadPath;
         if (downloadPath != null && !downloadPath.isBlank()) {
-            EnvVariableSingleton.getInstance().getVariables().put("DOWNLOAD_PATH", downloadPath);
+            EnvVariableSingleton.getInstance().getVariables().put("DOWNLOAD_PATH", downloadPath.trim());
         }
         this.consoleName = consoleName;
         if (consoleName != null && !consoleName.isBlank()) {
-            EnvVariableSingleton.getInstance().getVariables().put("CONSOLE_NAME", consoleName);
+            EnvVariableSingleton.getInstance().getVariables().put("CONSOLE_NAME", consoleName.trim());
         }
         this.accountNumber = accountNumber;
         if (accountNumber != null && !accountNumber.isBlank()) {
-            EnvVariableSingleton.getInstance().getVariables().put("ACCOUNT_NUMBER", accountNumber);
+            EnvVariableSingleton.getInstance().getVariables().put("ACCOUNT_NUMBER", accountNumber.trim());
         }
         this.browseLimit = browseLimit;
         if (browseLimit != null && !browseLimit.isBlank()) {
-            EnvVariableSingleton.getInstance().getVariables().put("BROWSE_LIMIT", browseLimit);
+            EnvVariableSingleton.getInstance().getVariables().put("BROWSE_LIMIT", browseLimit.trim());
         }
         this.prompt = prompt;
         if (prompt != null && !prompt.isBlank()) {
             EnvVariableSingleton.getInstance().getVariables().put("PROMPT", prompt);
         }
         this.window = window;
-    }
-
-    public String getHostName() {
-        return hostName;
-    }
-
-    public String getDownloadPath() {
-        return downloadPath;
-    }
-
-    public String getConsoleName() {
-        return consoleName;
-    }
-
-    public String getAccountNumber() {
-        return accountNumber;
-    }
-
-    public String getBrowseLimit() {
-        return browseLimit;
-    }
-
-    public String getPrompt() {
-        return prompt;
     }
 
     public Window getWindow() {

--- a/src/main/java/zos/shell/utility/PromptUtil.java
+++ b/src/main/java/zos/shell/utility/PromptUtil.java
@@ -26,7 +26,7 @@ public final class PromptUtil {
                 int endIndex = promptStr.indexOf(")");
                 if (endIndex != 1) {
                     var valueStr = promptStr.substring(startIndex + 2, endIndex);
-                    var replacePromptStr = envVariableController.getValueByEnv(valueStr.trim());
+                    var replacePromptStr = envVariableController.getValueByEnv(valueStr);
                     if (replacePromptStr != null && !replacePromptStr.isBlank()) {
                         promptStr = promptStr.replace("$(" + valueStr + ")", replacePromptStr);
                     }


### PR DESCRIPTION
The following PR updates the way environment variables are handled. ConfigSettings and EnvVariableSingleton classes are used to retrieve setting variables. 

As ConfigSettings stored some of the settings as environment variable(s) within EnvVariableSingleton, there was no need to have getter methods for those in ConfigSettings, use the singleton for retrieval. 

In addition, I found that issue #232 still existed when using the "SET" command for setting the ACCOUNT_NUMBER environment variable. Made changes to remove the numeric restriction there.  

Lastly, I refactored EnvVariableController class with code improvements for enhanced readability. 